### PR TITLE
Avoid kubeclient issue

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -23,6 +23,22 @@ require 'uri'
 RestClient.log = 'stdout'
 
 #
+# TODO: This is a hack to fix an issue with the `WatchNotice` class, see the following pull request
+# for details:
+#
+#   Recurse over arrays for watch notices
+#   https://github.com/abonas/kubeclient/pull/279
+#
+# It should be removed when a new version of the `kubeclient` gem is released and used by ManageIQ.
+#
+class ::Kubeclient::Common::WatchNotice
+  def initialize(hash = nil, args = {})
+    args[:recurse_over_arrays] = true
+    super(hash, args)
+  end
+end
+
+#
 # This class hides the fact that when connecting to KubeVirt we need to use different API servers:
 # one for the standard Kubernetes API and another one for the KubeVirt API.
 #

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -73,8 +73,8 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
 
     # Get the host name and the IP address:
     addresses = status.addresses
-    hostname = addresses.detect { |address| address['type'] == 'Hostname' }['address']
-    ip = addresses.detect { |address| address['type'] == 'InternalIP' }['address']
+    hostname = addresses.detect { |address| address.type == 'Hostname' }.address
+    ip = addresses.detect { |address| address.type == 'InternalIP' }.address
 
     # Get the node info:
     info = status.nodeInfo


### PR DESCRIPTION
The `kubeclient` gem does not provide exactly the same kind of objects inside notices and inside query responses. That should be fixed by abonas/kubeclient#279. Meanwhile this pull request introduces patches in the provider to avoid the issue.

The first  patch can and should be reverted when the issue in `kubeclient` is fixed. The second one should stay.