### PR TITLE
Add missing `Clone to VM` dialog

### DIFF
--- a/content/miq_dialogs/miq_provision_kubevirt_dialogs_clone_to_vm.yaml
+++ b/content/miq_dialogs/miq_provision_kubevirt_dialogs_clone_to_vm.yaml
@@ -1,0 +1,378 @@
+---
+:name: miq_provision_kubevirt_dialogs_clone_to_vm
+:description: Create virtual machine from template
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+            :order: []
+            :single_select: []
+            :exclude: []
+          :display: :edit
+          :required_tags: []
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :customize:
+      :description: Customize
+      :fields:
+        :dns_servers:
+          :description: DNS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :dns_suffixes:
+          :description: DNS Suffix list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :root_password:
+          :description: Root Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :addr_mode:
+          :values:
+            static: Static
+            dhcp: DHCP
+          :description: Address Mode
+          :required: false
+          :display: :edit
+          :default: static
+          :data_type: :string
+        :gateway:
+          :description: Gateway
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :ip_addr:
+          :description: IP Address
+          :required: false
+          :notes: (Enter starting IP address)
+          :display: :edit
+          :data_type: :string
+          :notes_display: :hide
+        :customization_template_script:
+          :description: Script Text
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :subnet_mask:
+          :description: Subnet Mask
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: VM Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: VM Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :vm_name:
+          :description: VM Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length:
+        :pxe_image_id:
+          :values_from:
+            :method: :allowed_images
+          :auto_select_single: false
+          :description: Image
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :iso_image_id:
+          :values_from:
+            :method: :allowed_iso_images
+          :auto_select_single: false
+          :description: Image
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :pxe_server_id:
+          :values_from:
+            :method: :allowed_pxe_servers
+          :auto_select_single: false
+          :description: Server
+          :required: true
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :vm_auto_start:
+          :values:
+            false: 0
+            true: 1
+          :description: Power on virtual machines after creation
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+        :stateless:
+          :values:
+            false: 0
+            true: 1
+          :description: Stateless
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+      :display: :show
+    :hardware:
+      :description: Hardware
+      :fields:
+        :number_of_sockets:
+          :values:
+            1: "1"
+            2: "2"
+            4: "4"
+            8: "8"
+          :description: Number of Sockets
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :cores_per_socket:
+          :values:
+            1: "1"
+            2: "2"
+            4: "4"
+            8: "8"
+          :description: Cores per Socket
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_memory:
+          :values:
+            "1024": "1024"
+            "2048": "2048"
+            "4096": "4096"
+            "8192": "8192"
+            "12288": "12288"
+            "16384": "16384"
+            "32768": "32768"
+          :description: Memory (MiB)
+          :required: false
+          :display: :edit
+          :default: "1024"
+          :data_type: :string
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :hardware
+  - :customize
+  - :schedule


### PR DESCRIPTION
The provider already supports provisioning of virtual machines from
templates, but the dialog is missing. This patch adds it.

Request tab:

![kubevirt-request](https://user-images.githubusercontent.com/1423971/34219208-c2b53032-e5b0-11e7-8ea0-0769de21b665.png)

Purpose tab:

![kubevirt-purpose](https://user-images.githubusercontent.com/1423971/34219221-cc1dec72-e5b0-11e7-9514-7a65adbc58e1.png)

Catalog tab:

![kubevirt-catalog](https://user-images.githubusercontent.com/1423971/34219233-d59f9908-e5b0-11e7-92a6-6fea9f987b8c.png)

Hardware tab:

![kubevirt-hardware](https://user-images.githubusercontent.com/1423971/34219253-df7f51b6-e5b0-11e7-911d-a345eafb96cc.png)

Schedule tab:

![kubevirt-schedule](https://user-images.githubusercontent.com/1423971/34219270-e946d8cc-e5b0-11e7-8398-959f4d546097.png)




