### PR TITLE
KubeVirt as a secondary manager of Container Providers

### DIFF
--- a/manageiq-providers-kubevirt.gemspec
+++ b/manageiq-providers-kubevirt.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_runtime_dependency "kubeclient", "~> 2.4.0"
+  s.add_runtime_dependency "manageiq-providers-kubernetes", "~> 0.1.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
The KubeVirt provider will be managed as a secondary provider of
OpenShift/Kubernetes providers.

The endpoint and authentication of kubevirt will reside under the
container providers, selected by the :kubevirt role and authkey.

Adding and removal of KubeVirt should be performed from the container
manager virtualization tab.

Depends on https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/197