### PR TITLE
Adjust the memory calculator to Kubevirt 0.2.0

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
@@ -65,10 +65,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Provision::Cloning
           template: {
             spec: {
               domain: {
-                memory: {
-                  value: memory.to_i,
-                  unit: 'MiB'
-                }
+                memory: memory.to_s + 'Mi'
               }
             }
           }

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -181,7 +181,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
 
     # Create the inventory object for the hardware:
     hw_object = hw_collection.find_or_build(vm_object)
-    hw_object.memory_mb = ManageIQ::Providers::Kubevirt::MemoryCalculator::convert(domain.memory.value, domain.memory.unit, 'MiB')
+    hw_object.memory_mb = ManageIQ::Providers::Kubevirt::MemoryCalculator::convert(domain.memory, 'Mi')
 
     # Return the created inventory object:
     vm_object
@@ -213,7 +213,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
 
     # Add the inventory object for the hardware:
     hw_object = hw_collection.find_or_build(template_object)
-    hw_object.memory_mb = ManageIQ::Providers::Kubevirt::MemoryCalculator::convert(domain.memory.value, domain.memory.unit, 'MiB')
+    hw_object.memory_mb = ManageIQ::Providers::Kubevirt::MemoryCalculator::convert(domain.memory, 'Mi')
   end
 
   def find_owner(object, kind)

--- a/app/models/manageiq/providers/kubevirt/memory_calculator.rb
+++ b/app/models/manageiq/providers/kubevirt/memory_calculator.rb
@@ -14,47 +14,100 @@
 # limitations under the License.
 #
 
+require 'bigdecimal'
+
 #
 # This class contains functions that do memory calculations.
 #
 class ManageIQ::Providers::Kubevirt::MemoryCalculator
   #
-  # Converts a value from one unit to another unit
+  # Converts a value containing an optional unit to another unit. For example, if the value is
+  # `2 MiB` and the unit is `KiB` the result will be 2048.
   #
-  # @param value [Integer] The value to convert.
-  # @param from_unit [String] ('B') The name of the unit used by the value, for example `KB`.
-  # @param to_unit [String] ('B') The name of the unit to convert to, for example `GiB`.
-  # @return [Integer] The converted value, rounded down to the nearest integer.
+  # @param value [String] The value to convert, with an optional unit suffix.
+  # @param to [Symbol] (:b) The name of the unit to convert to, for example `:gib`.
+  # @return [BigDecimal] The converted value.
   #
-  def self.convert(value, from_unit, to_unit)
-    from_unit ||= 'B'
-    from_multiplier = MEMORY_UNIT_MULTIPLIERS[from_unit]
-    to_unit ||= 'B'
-    to_multiplier = MEMORY_UNIT_MULTIPLIERS[to_unit]
-    value * from_multiplier / to_multiplier
+  def self.convert(value, to)
+    # Return nil if no value is given:
+    return nil unless value
+
+    # Try to extract the numeric value and the unit:
+    match = VALUE_RE.match(value)
+    raise ArgumentError, "The value '#{value}' isn't a valid memory unit" unless match
+    value = match[:value]
+    from = match[:suffix]
+
+    # Convert the value from string to big decimal to make sure that we don't loose precission:
+    value = BigDecimal.new(value)
+
+    # Do the conversion:
+    from_factor = scale_factor(from)
+    to_factor = scale_factor(to)
+    value * from_factor / to_factor
   end
 
   private
 
-  MEMORY_UNIT_MULTIPLIERS = {
-    'B' => 1,
+  #
+  # Regular expression used to match values and to separate them into the numeric value and the
+  # optional unit suffix.
+  #
+  VALUE_RE = /^\s*(?<value>[[:digit:]]+)\s*(?<suffix>[[:alpha:]]+)?\s*$/i
 
-    'KB' => 10**3,
-    'MB' => 10**6,
-    'GB' => 10**9,
-    'TB' => 10**12,
-    'PB' => 10**15,
-    'EB' => 10**18,
-    'ZB' => 10**21,
-    'YB' => 10**24,
+  #
+  # Scale factors associated to the diffeent unit suffixes.
+  #
+  SCALE_FACTORS = {
+    b: 1,
 
-    'KiB' => 2**10,
-    'MiB' => 2**20,
-    'GiB' => 2**30,
-    'TiB' => 2**40,
-    'PiB' => 2**50,
-    'EiB' => 2**60,
-    'ZiB' => 2**70,
-    'YiB' => 2**80
+    k: 10**3,
+    m: 10**6,
+    g: 10**9,
+    t: 10**12,
+    p: 10**15,
+    e: 10**18,
+    z: 10**21,
+    y: 10**24,
+
+    kb: 10**3,
+    mb: 10**6,
+    gb: 10**9,
+    tb: 10**12,
+    pb: 10**15,
+    eb: 10**18,
+    zb: 10**21,
+    yb: 10**24,
+
+    ki: 2**10,
+    mi: 2**20,
+    gi: 2**30,
+    ti: 2**40,
+    pi: 2**50,
+    ei: 2**60,
+    zi: 2**70,
+    yi: 2**80,
+
+    kib: 2**10,
+    mib: 2**20,
+    gib: 2**30,
+    tib: 2**40,
+    pib: 2**50,
+    eib: 2**60,
+    zib: 2**70,
+    yib: 2**80
   }.freeze
+
+  #
+  # Finds the scale factor that matches the given unit suffix.
+  #
+  # @param sufix [Symbol, String] The unit suffix, as symbol or string. For example `MiB` or `:mib`.
+  # @return [Integer] The scale factor corresponding to that unit.
+  #
+  def self.scale_factor(suffix)
+    suffix = suffix.downcase.to_sym if suffix.is_a?(String)
+    factor = SCALE_FACTORS[suffix]
+    raise ArgumentErr, "The value '#{suffix}' isn't a valid unit suffix" unless factor
+    factor
+  end
 end

--- a/manifests/example-template.yml
+++ b/manifests/example-template.yml
@@ -33,9 +33,7 @@ spec:
             type: network
           video:
           - type: qxl
-        memory:
-          unit: MB
-          value: 64
+        memory: 64MiB
         os:
           type:
             os: hvm

--- a/spec/models/manageiq/providers/kubevirt/memory_calculator_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/memory_calculator_spec.rb
@@ -17,91 +17,107 @@
 describe ManageIQ::Providers::Kubevirt::MemoryCalculator do
   describe '.convert' do
     it 'converts correctly units that correspond to powers of 10' do
-      expect(described_class.convert(1, 'KB', 'B')).to eq(10**3)
-      expect(described_class.convert(1, 'MB', 'B')).to eq(10**6)
-      expect(described_class.convert(1, 'GB', 'B')).to eq(10**9)
-      expect(described_class.convert(1, 'TB', 'B')).to eq(10**12)
-      expect(described_class.convert(1, 'PB', 'B')).to eq(10**15)
-      expect(described_class.convert(1, 'EB', 'B')).to eq(10**18)
-      expect(described_class.convert(1, 'ZB', 'B')).to eq(10**21)
-      expect(described_class.convert(1, 'YB', 'B')).to eq(10**24)
+      expect(described_class.convert('1KB', :b).to_i).to eq(10**3)
+      expect(described_class.convert('1MB', :b).to_i).to eq(10**6)
+      expect(described_class.convert('1GB', :b).to_i).to eq(10**9)
+      expect(described_class.convert('1TB', :b).to_i).to eq(10**12)
+      expect(described_class.convert('1PB', :b).to_i).to eq(10**15)
+      expect(described_class.convert('1EB', :b).to_i).to eq(10**18)
+      expect(described_class.convert('1ZB', :b).to_i).to eq(10**21)
+      expect(described_class.convert('1YB', :b).to_i).to eq(10**24)
     end
 
     it 'converts correctly units that correspond to powers of 2' do
-      expect(described_class.convert(1, 'KiB', 'B')).to eq(2**10)
-      expect(described_class.convert(1, 'MiB', 'B')).to eq(2**20)
-      expect(described_class.convert(1, 'GiB', 'B')).to eq(2**30)
-      expect(described_class.convert(1, 'TiB', 'B')).to eq(2**40)
-      expect(described_class.convert(1, 'PiB', 'B')).to eq(2**50)
-      expect(described_class.convert(1, 'EiB', 'B')).to eq(2**60)
-      expect(described_class.convert(1, 'ZiB', 'B')).to eq(2**70)
-      expect(described_class.convert(1, 'YiB', 'B')).to eq(2**80)
+      expect(described_class.convert('1KiB', :b).to_i).to eq(2**10)
+      expect(described_class.convert('1MiB', :b).to_i).to eq(2**20)
+      expect(described_class.convert('1GiB', :b).to_i).to eq(2**30)
+      expect(described_class.convert('1TiB', :b).to_i).to eq(2**40)
+      expect(described_class.convert('1PiB', :b).to_i).to eq(2**50)
+      expect(described_class.convert('1EiB', :b).to_i).to eq(2**60)
+      expect(described_class.convert('1ZiB', :b).to_i).to eq(2**70)
+      expect(described_class.convert('1YiB', :b).to_i).to eq(2**80)
     end
 
     it 'converts correclty powers of 10 to powers of 2' do
-      expect(described_class.convert(1000, 'KB', 'KiB')).to eq(976)
-      expect(described_class.convert(1000, 'MB', 'MiB')).to eq(953)
-      expect(described_class.convert(1000, 'GB', 'GiB')).to eq(931)
-      expect(described_class.convert(1000, 'TB', 'TiB')).to eq(909)
-      expect(described_class.convert(1000, 'PB', 'PiB')).to eq(888)
-      expect(described_class.convert(1000, 'EB', 'EiB')).to eq(867)
-      expect(described_class.convert(1000, 'ZB', 'ZiB')).to eq(847)
-      expect(described_class.convert(1000, 'YB', 'YiB')).to eq(827)
+      expect(described_class.convert('1000KB', :kib).to_i).to eq(976)
+      expect(described_class.convert('1000MB', :mib).to_i).to eq(953)
+      expect(described_class.convert('1000GB', :gib).to_i).to eq(931)
+      expect(described_class.convert('1000TB', :tib).to_i).to eq(909)
+      expect(described_class.convert('1000PB', :pib).to_i).to eq(888)
+      expect(described_class.convert('1000EB', :eib).to_i).to eq(867)
+      expect(described_class.convert('1000ZB', :zib).to_i).to eq(847)
+      expect(described_class.convert('1000YB', :yib).to_i).to eq(827)
     end
 
     it 'converts correclty powers of 2 to powers of 10' do
-      expect(described_class.convert(1000, 'KiB', 'KB')).to eq(1024)
-      expect(described_class.convert(1000, 'MiB', 'MB')).to eq(1048)
-      expect(described_class.convert(1000, 'GiB', 'GB')).to eq(1073)
-      expect(described_class.convert(1000, 'TiB', 'TB')).to eq(1099)
-      expect(described_class.convert(1000, 'PiB', 'PB')).to eq(1125)
-      expect(described_class.convert(1000, 'EiB', 'EB')).to eq(1152)
-      expect(described_class.convert(1000, 'ZiB', 'ZB')).to eq(1180)
-      expect(described_class.convert(1000, 'YiB', 'YB')).to eq(1208)
+      expect(described_class.convert('1000KiB', :kb).to_i).to eq(1024)
+      expect(described_class.convert('1000MiB', :mb).to_i).to eq(1048)
+      expect(described_class.convert('1000GiB', :gb).to_i).to eq(1073)
+      expect(described_class.convert('1000TiB', :tb).to_i).to eq(1099)
+      expect(described_class.convert('1000PiB', :pb).to_i).to eq(1125)
+      expect(described_class.convert('1000EiB', :eb).to_i).to eq(1152)
+      expect(described_class.convert('1000ZiB', :zb).to_i).to eq(1180)
+      expect(described_class.convert('1000YiB', :yb).to_i).to eq(1208)
     end
 
     it 'converts to smaller powers of 10 correclty' do
-      expect(described_class.convert(1, 'KB', 'B')).to eq(10**3)
-      expect(described_class.convert(1, 'MB', 'KB')).to eq(10**3)
-      expect(described_class.convert(1, 'GB', 'MB')).to eq(10**3)
-      expect(described_class.convert(1, 'TB', 'GB')).to eq(10**3)
-      expect(described_class.convert(1, 'PB', 'TB')).to eq(10**3)
-      expect(described_class.convert(1, 'EB', 'PB')).to eq(10**3)
-      expect(described_class.convert(1, 'ZB', 'EB')).to eq(10**3)
-      expect(described_class.convert(1, 'YB', 'ZB')).to eq(10**3)
+      expect(described_class.convert('1KB', 'B').to_i).to eq(10**3)
+      expect(described_class.convert('1MB', 'KB').to_i).to eq(10**3)
+      expect(described_class.convert('1GB', 'MB').to_i).to eq(10**3)
+      expect(described_class.convert('1TB', 'GB').to_i).to eq(10**3)
+      expect(described_class.convert('1PB', 'TB').to_i).to eq(10**3)
+      expect(described_class.convert('1EB', 'PB').to_i).to eq(10**3)
+      expect(described_class.convert('1ZB', 'EB').to_i).to eq(10**3)
+      expect(described_class.convert('1YB', 'ZB').to_i).to eq(10**3)
     end
 
     it 'converts to smaller powers of 2 correclty' do
-      expect(described_class.convert(1, 'KiB', 'B')).to eq(2**10)
-      expect(described_class.convert(1, 'MiB', 'KiB')).to eq(2**10)
-      expect(described_class.convert(1, 'GiB', 'MiB')).to eq(2**10)
-      expect(described_class.convert(1, 'TiB', 'GiB')).to eq(2**10)
-      expect(described_class.convert(1, 'PiB', 'TiB')).to eq(2**10)
-      expect(described_class.convert(1, 'EiB', 'PiB')).to eq(2**10)
-      expect(described_class.convert(1, 'ZiB', 'EiB')).to eq(2**10)
-      expect(described_class.convert(1, 'YiB', 'ZiB')).to eq(2**10)
+      expect(described_class.convert('1KiB', 'B').to_i).to eq(2**10)
+      expect(described_class.convert('1MiB', 'KiB').to_i).to eq(2**10)
+      expect(described_class.convert('1GiB', 'MiB').to_i).to eq(2**10)
+      expect(described_class.convert('1TiB', 'GiB').to_i).to eq(2**10)
+      expect(described_class.convert('1PiB', 'TiB').to_i).to eq(2**10)
+      expect(described_class.convert('1EiB', 'PiB').to_i).to eq(2**10)
+      expect(described_class.convert('1ZiB', 'EiB').to_i).to eq(2**10)
+      expect(described_class.convert('1YiB', 'ZiB').to_i).to eq(2**10)
     end
 
     it 'converts to larger powers of 10 correclty' do
-      expect(described_class.convert(10**3, 'B', 'KB')).to eq(1)
-      expect(described_class.convert(10**3, 'KB', 'MB')).to eq(1)
-      expect(described_class.convert(10**3, 'MB', 'GB')).to eq(1)
-      expect(described_class.convert(10**3, 'GB', 'TB')).to eq(1)
-      expect(described_class.convert(10**3, 'TB', 'PB')).to eq(1)
-      expect(described_class.convert(10**3, 'PB', 'EB')).to eq(1)
-      expect(described_class.convert(10**3, 'EB', 'ZB')).to eq(1)
-      expect(described_class.convert(10**3, 'ZB', 'YB')).to eq(1)
+      expect(described_class.convert('1000b', 'kb').to_i).to eq(1)
+      expect(described_class.convert('1000kb', 'mb').to_i).to eq(1)
+      expect(described_class.convert('1000mb', 'gb').to_i).to eq(1)
+      expect(described_class.convert('1000gb', 'tb').to_i).to eq(1)
+      expect(described_class.convert('1000tb', 'pb').to_i).to eq(1)
+      expect(described_class.convert('1000pb', 'eb').to_i).to eq(1)
+      expect(described_class.convert('1000eb', 'zb').to_i).to eq(1)
+      expect(described_class.convert('1000zb', 'yb').to_i).to eq(1)
     end
 
     it 'converts to larger powers of 2 correclty' do
-      expect(described_class.convert(2**10, 'B', 'KiB')).to eq(1)
-      expect(described_class.convert(2**10, 'KiB', 'MiB')).to eq(1)
-      expect(described_class.convert(2**10, 'MiB', 'GiB')).to eq(1)
-      expect(described_class.convert(2**10, 'GiB', 'TiB')).to eq(1)
-      expect(described_class.convert(2**10, 'TiB', 'PiB')).to eq(1)
-      expect(described_class.convert(2**10, 'PiB', 'EiB')).to eq(1)
-      expect(described_class.convert(2**10, 'EiB', 'ZiB')).to eq(1)
-      expect(described_class.convert(2**10, 'ZiB', 'YiB')).to eq(1)
+      expect(described_class.convert('1024b', 'ki').to_i).to eq(1)
+      expect(described_class.convert('1024kib', 'mi').to_i).to eq(1)
+      expect(described_class.convert('1024mib', 'gi').to_i).to eq(1)
+      expect(described_class.convert('1024gib', 'ti').to_i).to eq(1)
+      expect(described_class.convert('1024tib', 'pi').to_i).to eq(1)
+      expect(described_class.convert('1024pib', 'ei').to_i).to eq(1)
+      expect(described_class.convert('1024eib', 'zi').to_i).to eq(1)
+      expect(described_class.convert('1024zib', 'yi').to_i).to eq(1)
+    end
+
+    it 'accepts spaces between the numeric value and the unit suffix' do
+      expect(described_class.convert('2 KiB', :b).to_i).to eq(2048)
+    end
+
+    it 'accepts spaces before the numeric value' do
+      expect(described_class.convert(' 2KiB', :b).to_i).to eq(2048)
+    end
+
+    it 'accepts spaces after the unit suffix' do
+      expect(described_class.convert('2KiB ', :b).to_i).to eq(2048)
+    end
+
+    it 'returns nil if no value is given' do
+      expect(described_class.convert(nil, :b)).to be_nil
     end
   end
 end


### PR DESCRIPTION
In Kubevirt 0.2.0 the way that virtual machine memory is specified has
changed. In previous versions it was specified like this:

  memory:
    unit: MB
    value: 64

See the example here:

  https://github.com/kubevirt/kubevirt/blob/v0.1.0/cluster/vm.yaml#L34-L36

Since version 0.2.0 it is specified like this:

  memory: 64M

See the example here:

  https://github.com/kubevirt/kubevirt/blob/v0.2.0/cluster/vm.yaml#L10

This means that the `MemoryCalculator` class needs to be changed
accordingly to support the new format.

Also the provision request and the parsing of the reported virtual machines were updated to support the updated memory format.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>
Signed-off-by: Moti Asayag <masayag@redhat.com>