### PR TITLE
Don't put `RestClient` in debug mode

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -20,8 +20,6 @@ require 'ostruct'
 require 'rest-client'
 require 'uri'
 
-RestClient.log = 'stdout'
-
 #
 # TODO: This is a hack to fix an issue with the `WatchNotice` class, see the following pull request
 # for details:


### PR DESCRIPTION
Currently the provider puts the `RestClient` class in debug mode, doing
the following:

```ruby
RestClient.log = 'stdout'
```

This is a leftover of the initial development of the provider, when it
was very convenient for debugging. But now it should be removed, because
it affects this provider and also any other providers that use the same
gem.