### PR TITLE
Use `:resource_version` instead of `resourceVersion`

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -59,10 +59,10 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
     # Create the watches:
     @watches = []
     manager.with_provider_connection do |connection|
-      @watches << connection.watch_nodes('resourceVersion' => memory.get_list_version(:nodes))
-      @watches << connection.watch_offline_vms('resourceVersion' => memory.get_list_version(:offline_vms))
-      @watches << connection.watch_live_vms('resourceVersion' => memory.get_list_version(:live_vms))
-      @watches << connection.watch_templates('resourceVersion' => memory.get_list_version(:templates))
+      @watches << connection.watch_nodes(:resource_version => memory.get_list_version(:nodes))
+      @watches << connection.watch_offline_vms(:resource_version => memory.get_list_version(:offline_vms))
+      @watches << connection.watch_live_vms(:resource_version => memory.get_list_version(:live_vms))
+      @watches << connection.watch_templates(:resource_version => memory.get_list_version(:templates))
     end
 
     # Create the threads that run the watches and put the notices in the queue:


### PR DESCRIPTION
The parameter that the `kubeclient` gem uses to specify the resource
version for a watch is the `:resource_version` symbol, not the
`resourceVersion` string:

  https://github.com/abonas/kubeclient/blob/v2.4.0/lib/kubeclient/common.rb#L246

But the provider is using the string `resourceVersion` instead, which is
silently ignored.
