### PR TITLE
Support retire VM

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -186,6 +186,16 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Connection
   end
 
   #
+  # Deletes an offline virtual machine.
+  #
+  # @param name [String] The name of the virtual machine to delete.
+  # @param namespace [String] The namespace where virtual machine is defined.
+  #
+  def delete_offline_vm(name, namespace = nil)
+    kubevirt_client.delete_offline_virtual_machine(name, namespace)
+  end
+
+  #
   # Updates an offline virtual machine.
   #
   # @param update [Object] The update to send.

--- a/spec/factories/vm_kubevirt.rb
+++ b/spec/factories/vm_kubevirt.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :vm_kubevirt, :class => "ManageIQ::Providers::Kubevirt::InfraManager::Vm", :parent => :vm_infra do
+    vendor          "kubevirt"
+    raw_power_state "up"
+  end
+end

--- a/spec/models/manageiq/providers/kubevirt/infra_manager/vm/operations_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/infra_manager/vm/operations_spec.rb
@@ -1,0 +1,82 @@
+describe 'VM::Operations' do
+  let(:default_endpoint) do
+    FactoryGirl.create(:endpoint,
+                       :role       => 'default',
+                       :hostname   => 'host.example.com',
+                       :port       => 6443,
+                       :verify_ssl => 0)
+  end
+
+  let(:default_authentication) { FactoryGirl.create(:authentication, :authtype => 'bearer') }
+
+  let(:kubevirt_authentication) do
+    FactoryGirl.create(
+      :authentication,
+      :authtype => 'kubevirt',
+      :auth_key => '_'
+    )
+  end
+
+  let(:kubevirt_endpoint) do
+    EvmSpecHelper.local_miq_server(:zone => Zone.seed)
+    FactoryGirl.build(
+      :endpoint,
+      :role       => 'kubevirt',
+      :hostname   => 'host.example.com',
+      :port       => 6443,
+      :verify_ssl => false
+    )
+  end
+
+  let(:container_manager) do
+    FactoryGirl.create(
+      :ems_kubernetes,
+      :endpoints       => [
+        default_endpoint,
+        kubevirt_endpoint,
+      ],
+      :authentications => [
+        default_authentication,
+        kubevirt_authentication,
+      ],
+    )
+  end
+
+  context '#raw_destroy' do
+    let(:infra_manager) { container_manager.infra_manager }
+    let(:vm) { FactoryGirl.create(:vm_kubevirt, :ext_management_system => infra_manager) }
+    let(:connection) { double("connection") }
+    let(:live_vm_metadata) { double("live_vm_metadata", :namespace => "default") }
+    let(:offline_vm_metadata) { double("offline_vm_metadata", :namespace => "default") }
+    let(:live_vm) { double("live_vm", :metadata => live_vm_metadata) }
+    let(:offline_vm) { double("offline_vm", :metadata => offline_vm_metadata) }
+
+    context 'running vm' do
+      it 'removes an running vm from kubevirt provider' do
+        allow(connection).to receive(:live_vm).and_return(live_vm)
+        allow(connection).to receive(:offline_vm).and_return(offline_vm)
+        allow(infra_manager).to receive(:with_provider_connection).and_yield(connection)
+
+        expect(connection).to receive(:delete_live_vm)
+        expect(connection).to receive(:delete_offline_vm)
+
+        vm.raw_destroy
+      end
+    end
+
+    context 'stopped vm' do
+      it 'removes a stopped vm from kubevirt provider' do
+        require 'kubeclient'
+        error = KubeException.new(404, "entity not found", "")
+        allow(connection).to receive(:live_vm).and_raise(error)
+        allow(connection).to receive(:offline_vm).and_return(offline_vm)
+        allow(infra_manager).to receive(:with_provider_connection).and_yield(connection)
+
+        expect(connection).not_to receive(:delete_live_vm)
+        expect(connection).to receive(:delete_offline_vm)
+
+        vm.raw_destroy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Kubevirt supports retiring a Vm, regardless its state by removing its
live vm (for running vm) and its offline vm.