### PR TITLE
Add VM Provision dialog

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
@@ -35,10 +35,6 @@ class ManageIQ::Providers::Kubevirt::InfraManager::ProvisionWorkflow < MiqProvis
     get_value(@values[:provision_type]).to_s == 'native_clone'
   end
 
-  def supports_linked_clone?
-    supports_native_clone? && get_value(@values[:linked_clone])
-  end
-
   def allowed_provision_types(_options = {})
     {
       "native_clone" => "Native Clone"
@@ -51,14 +47,6 @@ class ManageIQ::Providers::Kubevirt::InfraManager::ProvisionWorkflow < MiqProvis
 
   def update_field_visibility
     super(:force_platform => 'linux')
-  end
-
-  def update_field_visibility_linked_clone(_options = {}, f)
-    show_flag = supports_native_clone? ? :edit : :hide
-    f[show_flag] << :linked_clone
-
-    show_flag = supports_linked_clone? ? :hide : :edit
-    f[show_flag] << :disk_format
   end
 
   def allowed_datacenters(_options = {})
@@ -82,23 +70,13 @@ class ManageIQ::Providers::Kubevirt::InfraManager::ProvisionWorkflow < MiqProvis
   end
 
   def allowed_storages(options = {})
-    return [] if (src = resources_for_ui).blank?
+    return [] if resources_for_ui.blank?
     result = super
-
-    if supports_linked_clone?
-      s_id = load_ar_obj(src[:vm]).storage_id
-      result = result.select { |s| s.id == s_id }
-    end
-
     result.select { |s| s.storage_domain_type == "data" }
   end
 
   def source_ems
     src = get_source_and_targets
     load_ar_obj(src[:ems])
-  end
-
-  def filter_allowed_hosts(all_hosts)
-    all_hosts
   end
 end

--- a/content/miq_dialogs/miq_provision_kubevirt_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_kubevirt_dialogs_template.yaml
@@ -1,0 +1,286 @@
+---
+:name: miq_provision_kubevirt_dialogs_template
+:description: Sample KubeVirt VM Provisioning Dialog
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+
+            :order: []
+
+            :single_select: []
+
+            :exclude: []
+
+          :display: :edit
+          :required_tags: []
+
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: VM Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 255
+        :vm_prefix:
+          :description: VM Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :provision_type:
+          :values_from:
+            :method: :allowed_provision_types
+          :description: Provision Type
+          :required: true
+          :display: :edit
+          :default: native_clone
+          :data_type: :string
+        :vm_name:
+          :description: VM Name
+          :required_method:
+          - :validate_vm_name
+          - :validate_regex
+          :required_regex: !ruby/regexp /\A[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\Z/
+          :required_regex_fail_details: The name must be composed of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length: 255
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :vm_auto_start:
+          :values:
+            false: 0
+            true: 1
+          :description: Power on virtual machines after creation
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+        :stateless:
+          :values:
+            false: 0
+            true: 1
+          :description: Stateless
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+      :display: :show
+    :hardware:
+      :description: Hardware
+      :fields:
+        :vm_memory:
+          :values:
+            "1024": "1024"
+            "2048": "2048"
+            "4096": "4096"
+            "8192": "8192"
+            "12288": "12288"
+            "16384": "16384"
+            "32768": "32768"
+          :description: Memory (MB)
+          :required: false
+          :display: :edit
+          :default: "1024"
+          :data_type: :string
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :hardware
+  - :schedule


### PR DESCRIPTION
Kubevirt is a virtualization provider that allows to create virtual
machines. Currently, it is pretty limited and not fully defined,
therefore the initial dialog allows the user to specific the VM memory
only.

For vm provisioning, the :linked_clone attribute is ignored, as the
decision of disk provision type is made by the storage backend.
In addition, we don't control the node on which the vm will be
scheduled, therefore the implementation of allowed_hosts is irrelevant in this
context.

The core PR that adds kubevirt's template to the eligible templates list:
https://github.com/ManageIQ/manageiq/pull/16873

**Request Tab**
![vm_provision_request_tab](https://user-images.githubusercontent.com/316242/35301748-0b96cb4a-0095-11e8-97f6-e4b016a68389.png)

**Catalog Tab**
![vm_provision_catalog_tab](https://user-images.githubusercontent.com/316242/35301744-0b23d8ba-0095-11e8-869a-c9dea8a69ef8.png)

**Hardware Tab**
![vm_provision_hardware_tab](https://user-images.githubusercontent.com/316242/35301746-0b4a1278-0095-11e8-9a28-63805584df8b.png)

**Schedule Tab**
![vm_provision_schedule_tab](https://user-images.githubusercontent.com/316242/35301736-ff5ec0f8-0094-11e8-8afa-731d84a6cf31.png)

**Invalid name error message**
![vm_provision_invalid_name](https://user-images.githubusercontent.com/316242/35301747-0b6d6fac-0095-11e8-99e7-d49bc6f8b2c1.png)

