### PR TITLE
Bump kubeclient to >=2.5.2 <2.6, drop monkey patch

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -21,22 +21,6 @@ require 'rest-client'
 require 'uri'
 
 #
-# TODO: This is a hack to fix an issue with the `WatchNotice` class, see the following pull request
-# for details:
-#
-#   Recurse over arrays for watch notices
-#   https://github.com/abonas/kubeclient/pull/279
-#
-# It should be removed when a new version of the `kubeclient` gem is released and used by ManageIQ.
-#
-class ::Kubeclient::Common::WatchNotice
-  def initialize(hash = nil, args = {})
-    args[:recurse_over_arrays] = true
-    super(hash, args)
-  end
-end
-
-#
 # This class hides the fact that when connecting to KubeVirt we need to use different API servers:
 # one for the standard Kubernetes API and another one for the KubeVirt API.
 #

--- a/manageiq-providers-kubevirt.gemspec
+++ b/manageiq-providers-kubevirt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency("kubeclient", "~> 2.4.0")
+  s.add_runtime_dependency("kubeclient", "~> 2.5.2")
   s.add_runtime_dependency("manageiq-providers-kubernetes", "~> 0.1.0")
 
   s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")


### PR DESCRIPTION
- [x] core dependency relaxed to `~>2.4` https://github.com/ManageIQ/manageiq/pull/16957 
- [x] simulatenous bump https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/232

Reverted monkey patch from #2.

https://bugzilla.redhat.com/show_bug.cgi?id=1507528

miq-bot add-label bug, ~~gaprindashvili/yes~~ (this repo didn't exist then)

(On master, we'll later upgrade to kubeclient 3.0.0, need to resolve a version conflict first. On gaprindashvili, we'll stay with 2.5.)

@pkliczewski @masayag @jhernand please review.