### PR TITLE
templates: fix typo

### DIFF
--- a/manifests/example-template-windows.yml
+++ b/manifests/example-template-windows.yml
@@ -6,7 +6,7 @@ metadata:
     description: "OCP kubevirt windows VM template"
     tags: "kubevirt,ocp,template,windows"
   labels:
-    miq.github.io/kubvirt-os: windows-2016
+    miq.github.io/kubevirt-os: windows-2016
     miq.github.io/kubevirt-is-vm-template: true
 objects:
 - apiVersion: kubevirt.io/v1alpha1

--- a/manifests/example-template.yml
+++ b/manifests/example-template.yml
@@ -6,7 +6,7 @@ metadata:
     description: "OCP kubevirt linux, template"
     tags: "kubevirt,ocp,template,linux"
   labels:
-    miq.github.io/kubvirt-os: rhel-7
+    miq.github.io/kubevirt-os: rhel-7
     miq.github.io/kubevirt-is-vm-template: true
 objects:
 - apiVersion: kubevirt.io/v1alpha1


### PR DESCRIPTION
should be "kubevirt" not "kubvirt" (note missing "e")