### PR TITLE
Make templates consumable by openshift

### DIFF
--- a/manifests/example-template-windows.yml
+++ b/manifests/example-template-windows.yml
@@ -7,7 +7,7 @@ metadata:
     tags: "kubevirt,ocp,template,windows"
   labels:
     miq.github.io/kubevirt-os: windows-2016
-    miq.github.io/kubevirt-is-vm-template: true
+    miq.github.io/kubevirt-is-vm-template: "true"
 objects:
 - apiVersion: kubevirt.io/v1alpha1
   kind: OfflineVirtualMachine
@@ -69,4 +69,4 @@ parameters:
   value: 4096Mi
 - name: CPU_CORES
   description: Amount of cores
-  value: 4
+  value: "4"

--- a/manifests/example-template.yml
+++ b/manifests/example-template.yml
@@ -7,7 +7,7 @@ metadata:
     tags: "kubevirt,ocp,template,linux"
   labels:
     miq.github.io/kubevirt-os: rhel-7
-    miq.github.io/kubevirt-is-vm-template: true
+    miq.github.io/kubevirt-is-vm-template: "true"
 objects:
 - apiVersion: kubevirt.io/v1alpha1
   kind: OfflineVirtualMachine
@@ -53,4 +53,4 @@ parameters:
   value: 4096Mi
 - name: CPU_CORES
   description: Amount of cores
-  value: 4
+  value: "4"

--- a/manifests/working-template.yml
+++ b/manifests/working-template.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: v1
 kind: Template
 metadata:
   name: working
@@ -6,7 +6,7 @@ metadata:
     description: "OCP kubevirt linux, template"
     tags: "kubevirt,ocp,template,linux"
   labels:
-    miq.github.io/kubevirt-is-vm-template: true
+    miq.github.io/kubevirt-is-vm-template: "true"
     miq.github.io/kubevirt-os: rhel-7
 objects:
 - apiVersion: kubevirt.io/v1alpha1
@@ -49,4 +49,4 @@ parameters:
   value: 512Mi
 - name: CPU_CORES
   description: Amount of cores
-  value: 4
+  value: "4"

--- a/spec/fixtures/files/offline_vm.yml
+++ b/spec/fixtures/files/offline_vm.yml
@@ -8,7 +8,7 @@
     :spec:
       :domain:
         :cpu:
-          :cores: 4
+          :cores: "4"
         :resources:
           :requests:
             :memory: 4096Mi

--- a/spec/fixtures/files/offline_vm_registry.yml
+++ b/spec/fixtures/files/offline_vm_registry.yml
@@ -8,7 +8,7 @@
     :spec:
       :domain:
         :cpu:
-          :cores: 4
+          :cores: "4"
         :resources:
           :requests:
             :memory: 4096Mi

--- a/spec/fixtures/files/offlinevm_registry.json
+++ b/spec/fixtures/files/offlinevm_registry.json
@@ -16,7 +16,7 @@
       "spec": {
         "domain": {
           "cpu": {
-            "cores": 4
+            "cores": "4"
           },
           "resources": {
             "requests": {

--- a/spec/fixtures/files/template.json
+++ b/spec/fixtures/files/template.json
@@ -9,7 +9,7 @@
     "clusterName": "",
     "creationTimestamp": "2018-01-24T10:15:25Z",
     "labels": {
-      "miq.github.io/kubevirt-is-vm-template": true,
+      "miq.github.io/kubevirt-is-vm-template": "true",
       "miq.github.io/kubevirt-os": "rhel-7"
     },
     "name": "example",
@@ -23,7 +23,7 @@
       "spec": {
         "domain": {
           "cpu": {
-            "cores": 4
+            "cores": "4"
           },
           "devices": {
             "disks": [

--- a/spec/fixtures/files/template_registry.json
+++ b/spec/fixtures/files/template_registry.json
@@ -9,7 +9,7 @@
     "clusterName": "",
     "creationTimestamp": "2018-01-24T10:15:25Z",
     "labels": {
-      "miq.github.io/kubevirt-is-vm-template": true,
+      "miq.github.io/kubevirt-is-vm-template": "true",
       "miq.github.io/kubevirt-os": "rhel-7"
     },
     "name": "working",
@@ -23,7 +23,7 @@
       "spec": {
         "domain": {
           "cpu": {
-            "cores": 4
+            "cores": "4"
           },
           "resources": {
             "requests": {


### PR DESCRIPTION
There were issues with our example templates. This patch fixes them so
we can use `oc` tool to create them.