### PR TITLE
Improve kubevirt detection

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -104,7 +104,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   # on top of the kubernetes cluster
   #
   def verify_virt_supported
-    with_provider_connection(&:live_vms)
+    with_provider_connection(&:virt_supported?)
   end
 
   #

--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -90,6 +90,15 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Connection
     # credentials are wrong.
   end
 
+  def virt_supported?
+    api_versions = kubevirt_client.api["versions"]
+    virt_enabled = api_versions.each do |ver|
+      break true if ver["groupVersion"].start_with?(KUBEVIRT_GROUP)
+    end
+
+    virt_enabled
+  end
+
   #
   # Checks if the connection is valid.
   #


### PR DESCRIPTION
In order to find out if kubevirt is deployed on the kubernetes cluster,
we'll query the reported API versions for the existence of
'kubevirt.io'.