### PR TITLE
Support livevms if provisioned without offlinevms

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -148,16 +148,14 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
 
     # Get the identifier of the offline virtual machine from the owner reference:
     owner = find_owner(object, 'OfflineVirtualMachine')
-    unless owner
-      _log.info(
-        "Live virtual machine with name '#{name}' and identifier '#{uid}' isn't owned by an offline virtual " \
-        "machine; it will be ignored"
-      )
-      return
+    unless owner.nil?
+      # seems like valid use case for now
+      uid = owner.uid
+      name = owner.name
     end
 
     # Process the domain:
-    vm_object = process_domain(domain, owner.uid, owner.name)
+    vm_object = process_domain(domain, uid, name)
 
     # If the live virtual machine exists, then the it is powered on, regardless of the value of the `running` field of
     # the status:

--- a/spec/fixtures/files/vm.json
+++ b/spec/fixtures/files/vm.json
@@ -1,0 +1,64 @@
+{
+    "apiVersion": "kubevirt.io/v1alpha1",
+    "kind": "VirtualMachine",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"kubevirt.io/v1alpha1\",\"kind\":\"VirtualMachine\",\"metadata\":{\"annotations\":{},\"name\":\"demo-vm\",\"namespace\":\"default\"},\"spec\":{\"domain\":{\"devices\":{\"disks\":[{\"disk\":{\"dev\":\"vda\"},\"name\":\"mydisk\",\"volumeName\":\"pvcvolume\"}]},\"resources\":{\"requests\":{\"memory\":\"64M\"}}},\"terminationGracePeriodSeconds\":0,\"volumes\":[{\"name\":\"pvcvolume\",\"persistentVolumeClaim\":{\"claimName\":\"demo-vm-tinycore\"}}]}}\n"
+        },
+        "clusterName": "",
+        "creationTimestamp": "2018-02-27T14:15:11Z",
+        "generation": 0,
+        "labels": {
+            "kubevirt.io/nodeName": "vm-17-235.eng.lab.tlv.redhat.com"
+        },
+        "name": "demo-vm",
+        "namespace": "default",
+        "resourceVersion": "918478",
+        "selfLink": "/apis/kubevirt.io/v1alpha1/namespaces/default/virtualmachines/demo-vm",
+        "uid": "9f3a8f56-1bc8-11e8-a746-001a4a23138b"
+    },
+    "spec": {
+        "domain": {
+            "devices": {
+                "disks": [
+                    {
+                        "disk": {
+                            "bus": "sata"
+                        },
+                        "name": "mydisk",
+                        "volumeName": "pvcvolume"
+                    }
+                ]
+            },
+            "features": {
+                "acpi": {
+                    "enabled": true
+                }
+            },
+            "firmware": {
+                "uuid": "7ea133d0-ee05-4945-a2ed-16721ce0e428"
+            },
+            "machine": {
+                "type": "q35"
+            },
+            "resources": {
+                "requests": {
+                    "memory": "64M"
+                }
+            }
+        },
+        "terminationGracePeriodSeconds": 0,
+        "volumes": [
+            {
+                "name": "pvcvolume",
+                "persistentVolumeClaim": {
+                    "claimName": "demo-vm-tinycore"
+                }
+            }
+        ]
+    },
+    "status": {
+        "nodeName": "vm-17-235.eng.lab.tlv.redhat.com",
+        "phase": "Running"
+    }
+}

--- a/spec/models/manageiq/providers/kubevirt/inventory/parse_vm_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/parse_vm_spec.rb
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require './spec/support/file_helpers'
+
+RSpec.configure do |c|
+  c.include FileHelpers
+end
+
+describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
+  describe '#process_vms' do
+    it 'parses a vm' do
+      storage_collection = double("storage_collection")
+      storage = FactoryGirl.create(:storage)
+      allow(storage_collection).to receive(:lazy_find).and_return(storage)
+
+      hw_collection = double("hw_collection")
+      hardware = FactoryGirl.create(:hardware)
+      allow(hw_collection).to receive(:find_or_build).and_return(hardware)
+
+      vm_collection = double("vm_collection")
+      vm = FactoryGirl.create(:vm_kubevirt, :hardware => hardware)
+      allow(vm_collection).to receive(:find_or_build).and_return(vm)
+
+      parser = described_class.new
+      parser.instance_variable_set(:@storage_collection, storage_collection)
+      parser.instance_variable_set(:@vm_collection, vm_collection)
+      parser.instance_variable_set(:@hw_collection, hw_collection)
+
+      parser.send(:process_live_vm, unprocessed_object("vm.json"))
+
+      expect(vm).to have_attributes(
+        :name             => "demo-vm",
+        :template         => false,
+        :ems_ref          => "9f3a8f56-1bc8-11e8-a746-001a4a23138b",
+        :ems_ref_obj      => "9f3a8f56-1bc8-11e8-a746-001a4a23138b",
+        :uid_ems          => "9f3a8f56-1bc8-11e8-a746-001a4a23138b",
+        :vendor           => ManageIQ::Providers::Kubevirt::Constants::VENDOR,
+        :power_state      => "on",
+        :location         => "unknown",
+        :connection_state => "connected",
+      )
+    end
+  end
+end


### PR DESCRIPTION
It is acceptable not to have owner reference when a vm was not created
using offlinevm.