### PR TITLE
Use guest os label

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -33,6 +33,11 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
   #
   STORAGE_ID = '0'.freeze
 
+  #
+  # Label name which identifies operation system information
+  #
+  OS_LABEL = 'kubevirt.io/os'.freeze
+
   attr_reader :cluster_collection
   attr_reader :host_collection
   attr_reader :host_storage_collection
@@ -236,7 +241,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
     cpu = default_value(params, 'CPU_CORES')
     hw_object.cpu_cores_per_socket = cpu
     hw_object.cpu_total_cores = cpu
-    hw_object.guest_os = metadata.labels.send("miq.github.io/kubevirt-os")
+    hw_object.guest_os = metadata.labels.send(OS_LABEL)
 
     # Add the inventory objects for the disk:
     process_disks(hw_object, domain)
@@ -269,7 +274,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
 
   def process_os(template_object, metadata)
     os_object = vm_os_collection.find_or_build(template_object)
-    os_object.product_name = metadata.labels.send("miq.github.io/kubevirt-os")
+    os_object.product_name = metadata.labels.send(OS_LABEL)
     os_object.product_type = if metadata.annotations.tags.include?("linux")
                                "linux"
                              elsif metadata.annotations.tags.include?("windows")

--- a/manifests/working-template.yml
+++ b/manifests/working-template.yml
@@ -7,7 +7,7 @@ metadata:
     tags: "kubevirt,ocp,template,linux"
   labels:
     miq.github.io/kubevirt-is-vm-template: "true"
-    miq.github.io/kubevirt-os: rhel-7
+    kubevirt.io/os: rhel-7
 objects:
 - apiVersion: kubevirt.io/v1alpha1
   kind: OfflineVirtualMachine

--- a/spec/fixtures/files/template.json
+++ b/spec/fixtures/files/template.json
@@ -10,7 +10,7 @@
     "creationTimestamp": "2018-01-24T10:15:25Z",
     "labels": {
       "miq.github.io/kubevirt-is-vm-template": "true",
-      "miq.github.io/kubevirt-os": "rhel-7"
+      "kubevirt.io/os": "rhel-7"
     },
     "name": "example",
     "namespace": "default",

--- a/spec/fixtures/files/template_registry.json
+++ b/spec/fixtures/files/template_registry.json
@@ -10,7 +10,7 @@
     "creationTimestamp": "2018-01-24T10:15:25Z",
     "labels": {
       "miq.github.io/kubevirt-is-vm-template": "true",
-      "miq.github.io/kubevirt-os": "rhel-7"
+      "kubevirt.io/os": "rhel-7"
     },
     "name": "working",
     "namespace": "default",


### PR DESCRIPTION
There is a change in label name how we expose os information.

This PR was pushed because https://github.com/kubevirt/user-guide/pull/25 was merged.