### PR TITLE
Role kubevirt-infra was removed

### DIFF
--- a/manifests/account-kubernetes.yml
+++ b/manifests/account-kubernetes.yml
@@ -17,16 +17,3 @@ subjects:
   name: miq-account
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: miq-kubevirt-admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubevirt-infra
-subjects:
-- kind: ServiceAccount
-  name: miq-account
-  namespace: default
----

--- a/manifests/account-openshift.yml
+++ b/manifests/account-openshift.yml
@@ -17,16 +17,3 @@ subjects:
   name: my-account
   namespace: default
 ---
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: my-kubevirt-admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubevirt-infra
-subjects:
-- kind: ServiceAccount
-  name: my-account
-  namespace: default
----


### PR DESCRIPTION
We do not need kubevirt-infra role in our manifests since it was removed.
It is enough to use cluster-admin.