### PR TITLE
Stop persisting resource versions

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -84,7 +84,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
   # @return [ManageIQ::Providers::Kubevirt::RefreshMemory] The refresh memory.
   #
   def memory
-    @memory ||= ManageIQ::Providers::Kubevirt::RefreshMemory.new(manager.id)
+    @memory ||= ManageIQ::Providers::Kubevirt::RefreshMemory.new
   end
 
   #


### PR DESCRIPTION
With previous changes we need to perform full refresh when a worker starts and
whenever watches expire which means we have the latest resource versions. It is
enough to keep them in memory.