### PR TITLE
Use core client to query for supported versions

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -104,7 +104,9 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   # on top of the kubernetes cluster
   #
   def verify_virt_supported
-    with_provider_connection(&:virt_supported?)
+    virt_supported = with_provider_connection(&:virt_supported?)
+    raise "Kubevirt deployment was not found on provider" unless virt_supported
+    virt_supported
   end
 
   #

--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -91,9 +91,17 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Connection
   end
 
   def virt_supported?
-    api_versions = kubevirt_client.api["versions"]
-    virt_enabled = api_versions.each do |ver|
-      break true if ver["groupVersion"].start_with?(KUBEVIRT_GROUP)
+    virt_enabled = false
+    begin
+      api_versions = kubevirt_client.api["versions"]
+      api_versions.each do |ver|
+        if ver["groupVersion"]&.start_with?(KUBEVIRT_GROUP)
+          virt_enabled = true
+        end
+      end
+    rescue => err
+      # we failed to communicate or to evaluate the version format
+      $log.warn("Failed to detect kubevirt on provider with error: #{err.message}")
     end
 
     virt_enabled


### PR DESCRIPTION
In order to avoid 404 when kubevirt isn't deployed, the core client
should be used to check if kubevirt version is available.

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/44