### PR TITLE
Respect user hardware attributes

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
@@ -47,7 +47,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Provision::Cloning
       template = connection.template(source.name)
     end
 
-    params = values(template, options)
+    params = values(template, user_options(options))
 
     # use persistent volume claims if any from a template and send
     create_persistent_volume_claims(persistent_volume_claims_from_objects(template.objects), params, template.metadata.namespace)
@@ -227,5 +227,19 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Provision::Cloning
       result = result.map { |v| to_hash(v) }
     end
     result
+  end
+
+  #
+  # Merges user given options with user options that are specified on the request.
+  # The returned Hash will contain keys as expected by the kubevirt template.
+  #
+  # @param options [Hash] the given options by the user
+  # @return [Hash] Hash that contains additional user options as specified on the request
+  #
+  def user_options(options)
+    merged_options = options.dup
+    merged_options[:cpu_cores] = get_option(:cores_per_socket)
+    merged_options[:memory] = get_option(:vm_memory)
+    merged_options.compact
   end
 end

--- a/content/miq_dialogs/miq_provision_kubevirt_dialogs_clone_to_vm.yaml
+++ b/content/miq_dialogs/miq_provision_kubevirt_dialogs_clone_to_vm.yaml
@@ -340,7 +340,7 @@
             8: "8"
           :description: Number of Sockets
           :required: false
-          :display: :edit
+          :display: :hide
           :default: 1
           :data_type: :integer
         :cores_per_socket:

--- a/content/miq_dialogs/miq_provision_kubevirt_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_kubevirt_dialogs_template.yaml
@@ -263,6 +263,25 @@
     :hardware:
       :description: Hardware
       :fields:
+        :number_of_sockets:
+          :values:
+            1: "1"
+          :description: Number of Sockets
+          :required: false
+          :display: :hide
+          :default: 1
+          :data_type: :integer
+        :cores_per_socket:
+          :values:
+            1: "1"
+            2: "2"
+            4: "4"
+            8: "8"
+          :description: Cores per Socket
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
         :vm_memory:
           :values:
             "1024": "1024"

--- a/spec/fixtures/files/template_registry.json
+++ b/spec/fixtures/files/template_registry.json
@@ -30,11 +30,11 @@
           "spec": {
             "domain": {
               "cpu": {
-                "cores": "4"
+                "cores": "${CPU_CORES}"
               },
               "resources": {
                 "requests": {
-                  "memory": "4096Mi"
+                  "memory": "${MEMORY}"
                 }
               },
               "machine": {

--- a/spec/models/manageiq/providers/kubevirt/infra_manager/provision/cloning_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/infra_manager/provision/cloning_spec.rb
@@ -52,12 +52,15 @@ describe ManageIQ::Providers::Kubevirt::InfraManager::Provision do
     allow(connection).to receive(:template).and_return(unprocessed_object("template_registry.json"))
     allow(source).to receive(:with_provider_connection).and_yield(connection)
     allow(source).to receive(:name).and_return("test")
+    allow(subject).to receive(:get_option).with(:vm_memory).and_return("4096")
+    allow(subject).to receive(:get_option).with(:cores_per_socket).and_return("4")
+
     expect(connection).to receive(:create_offline_vm) do |offline_vm|
       expect(offline_vm).not_to be_nil
       expect(offline_vm).to eq(unprocessed_hash("offline_vm_registry.yml"))
       unprocessed_object("offlinevm_registry.json")
     end
 
-    subject.start_clone(:name => "test", :memory => 4096)
+    subject.start_clone(:name => "test")
   end
 end


### PR DESCRIPTION
Kubevirt supports memory and cores as hardware attributes.
In order to pass those to kubevirt, a mapping is required to the
expected attribute names on kubevirt side.

![selection_409](https://user-images.githubusercontent.com/316242/37400669-4b39fec8-278e-11e8-9fe2-993744338f83.png)
