### PR TITLE
Save network information for live vms

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/collections.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/collections.rb
@@ -185,5 +185,17 @@ class ManageIQ::Providers::Kubevirt::Inventory::Collections < ManagerRefresh::In
 
       attributes.merge!(extra_attributes)
     end
+
+    def networks(extra_attributes = {})
+      attributes = {
+        :model_class                  => ::Network,
+        :manager_ref                  => %i(hardware ipaddress),
+        :parent_inventory_collections => [:vms],
+        :association                  => :networks,
+        :inventory_object_attributes  => %i(ipaddress hostname)
+      }
+
+      attributes.merge!(extra_attributes)
+    end
   end
 end

--- a/app/models/manageiq/providers/kubevirt/inventory/parser/full_refresh.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser/full_refresh.rb
@@ -30,6 +30,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser::FullRefresh < ManageIQ::
     @host_collection = persister.host_collection
     @host_storage_collection = persister.host_storage_collection
     @hw_collection = persister.hw_collection
+    @network_collection = persister.network_collection
     @os_collection = persister.os_collection
     @storage_collection = persister.storage_collection
     @template_collection = persister.template_collection

--- a/app/models/manageiq/providers/kubevirt/inventory/parser/partial_refresh.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser/partial_refresh.rb
@@ -54,6 +54,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser::PartialRefresh < ManageI
     @host_collection = persister.host_collection(:targeted => true, :ids => host_ids)
     @host_storage_collection = persister.host_storage_collection(:targeted => true)
     @hw_collection = persister.hw_collection(:targeted => true)
+    @network_collection = persister.network_collection(:targeted => true)
     @os_collection = persister.os_collection(:targeted => true)
     @storage_collection = persister.storage_collection(:targeted => true, :ids => storage_ids)
     @template_collection = persister.template_collection(:targeted => true, :ids => template_ids)

--- a/app/models/manageiq/providers/kubevirt/inventory/parser/partial_target_refresh.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser/partial_target_refresh.rb
@@ -38,6 +38,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser::PartialTargetRefresh < M
     @host_collection = persister.host_collection(:targeted => true, :ids => host_ids)
     @host_storage_collection = persister.host_storage_collection(:targeted => true)
     @hw_collection = persister.hw_collection(:targeted => true)
+    @network_collection = persister.network_collection(:targeted => true)
     @os_collection = persister.os_collection(:targeted => true)
     @storage_collection = persister.storage_collection(:targeted => true, :ids => storage_ids)
     @template_collection = persister.template_collection(:targeted => true, :ids => template_ids)

--- a/app/models/manageiq/providers/kubevirt/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/persister.rb
@@ -52,6 +52,14 @@ class ManageIQ::Providers::Kubevirt::Inventory::Persister < ManagerRefresh::Inve
     add_inventory_collection(attributes)
   end
 
+  def network_collection(targeted: false)
+    attributes = ManageIQ::Providers::Kubevirt::Inventory::Collections.networks(
+      :targeted => targeted,
+      :strategy => :local_db_find_missing_references
+    )
+    add_inventory_collection(attributes)
+  end
+
   def os_collection(targeted: false)
     attributes = ManageIQ::Providers::Kubevirt::Inventory::Collections.host_operating_systems(
       :targeted => targeted,

--- a/spec/fixtures/files/vm.json
+++ b/spec/fixtures/files/vm.json
@@ -58,6 +58,11 @@
         ]
     },
     "status": {
+        "interfaces": [
+            {
+                "ipAddress": "10.128.0.18"
+            }
+        ],
         "nodeName": "vm-17-235.eng.lab.tlv.redhat.com",
         "phase": "Running"
     }


### PR DESCRIPTION
Saves the IP address and hostname if exists for a live vm entity.

![selection_523](https://user-images.githubusercontent.com/316242/38548606-d5cc4230-3cba-11e8-8140-d6cb939f33f3.png)
