### PR TITLE
Save OS label for Offline VM

### DIFF
--- a/spec/fixtures/files/offline_vm.yml
+++ b/spec/fixtures/files/offline_vm.yml
@@ -3,6 +3,8 @@
 :metadata:
   :name: test
   :namespace: default
+  :labels:
+      "kubevirt.io/os": "rhel-7"
 :spec:
   :template:
     :spec:

--- a/spec/fixtures/files/offline_vm_registry.yml
+++ b/spec/fixtures/files/offline_vm_registry.yml
@@ -3,6 +3,8 @@
 :metadata:
   :name: test
   :namespace: default
+  :labels:
+    "kubevirt.io/os": "rhel-7"
 :spec:
   :template:
     :spec:


### PR DESCRIPTION
The OS label should be copied from the template to the offline vm
on creation. It also has to be parsed when offline vm is collected
and parsed, so MIQ will be able to present a proper icon and
description when the vm is being viewed.

![selection_534](https://user-images.githubusercontent.com/316242/38668812-6ab9bd4e-3e4d-11e8-983a-8b202ffcef4e.png)
