### PR TITLE
Provide :running attribute

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
@@ -72,6 +72,9 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Provision::Cloning
     os_label = ManageIQ::Providers::Kubevirt::Inventory::Parser::OS_LABEL
 
     offline_vm.deep_merge!(
+      :spec     => {
+        :running  => false
+      },
       :metadata => {
         :namespace => metadata.namespace,
         :labels    => {

--- a/spec/fixtures/files/offline_vm.yml
+++ b/spec/fixtures/files/offline_vm.yml
@@ -6,6 +6,7 @@
   :labels:
       "kubevirt.io/os": "rhel-7"
 :spec:
+  :running: false
   :template:
     :spec:
       :domain:

--- a/spec/fixtures/files/offline_vm_registry.yml
+++ b/spec/fixtures/files/offline_vm_registry.yml
@@ -6,6 +6,7 @@
   :labels:
     "kubevirt.io/os": "rhel-7"
 :spec:
+  :running: false
   :template:
     :spec:
       :domain:


### PR DESCRIPTION
kubevirt v0.4.0 expects the :running attribute to be provided, even for an offline vm.
Without it, creation of offlinevm fails with:

> spec.running in body is required

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/59