### PR TITLE
Use vm status provided by kubevirt

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
@@ -17,8 +17,18 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
   include_concern 'Operations'
 
+  POWER_STATES = {
+    'Running'    => 'on',
+    'Pending'    => 'powering_up',
+    'Scheduling' => 'powering_up',
+    'Scheduled'  => 'off',
+    'Succeeded'  => 'off',
+    'Failed'     => 'off',
+    'Unknown'    => 'terminated'
+  }.freeze
+
   def self.calculate_power_state(raw)
-    raw
+    POWER_STATES[raw] || super
   end
 
   #

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -122,7 +122,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
     process_os(vm_object, object.labels, object.annotations)
 
     # The power status is initially off, it will be set to on later if the live virtual machine exists:
-    vm_object.raw_power_state = 'off'
+    vm_object.raw_power_state = 'Succeeded'
   end
 
   def process_live_vms(objects)
@@ -147,9 +147,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
     vm_object = process_domain(object.memory, object.cpu_cores, uid, name)
     process_status(vm_object, object.ip_address, object.node_name)
 
-    # If the live virtual machine exists, then the it is powered on, regardless of the value of the `running` field of
-    # the status:
-    vm_object.raw_power_state = 'on'
+    vm_object.raw_power_state = object.status
   end
 
   def process_domain(memory, cores, uid, name)

--- a/app/models/manageiq/providers/kubevirt/refresh_memory.rb
+++ b/app/models/manageiq/providers/kubevirt/refresh_memory.rb
@@ -104,6 +104,6 @@ class ManageIQ::Providers::Kubevirt::RefreshMemory
   # Calculates the key that will be used to store a notice.
   #
   def notice_key(notice)
-    "#{notice.kind}:#{notice.uid}:#{notice.type}:#{notice.resource_version}"
+    "#{notice.kind}:#{notice.resource_version}"
   end
 end

--- a/manageiq-providers-kubevirt.gemspec
+++ b/manageiq-providers-kubevirt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency("fog-kubevirt", "~> 0.1.1")
+  s.add_runtime_dependency("fog-kubevirt", "~> 0.1.2")
   s.add_runtime_dependency("manageiq-providers-kubernetes", "~> 0.1.0")
 
   s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")

--- a/spec/models/manageiq/providers/kubevirt/inventory/parse_vm_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/parse_vm_spec.rb
@@ -53,7 +53,8 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
         :cpu_cores  => "2",
         :ip_address => "10.128.0.18",
         :node_name  => "vm-17-235.eng.lab.tlv.redhat.com",
-        :owner_name => nil
+        :owner_name => nil,
+        :status     => "Running"
       )
 
       parser.send(:process_live_vm, source)


### PR DESCRIPTION
We assumed about vm status based on part of the flow we were in.
This PR uses vm status as collected from kubevirt.