### PR TITLE
Validate VM name based on DNS-1123

### DIFF
--- a/content/miq_dialogs/miq_provision_kubevirt_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_kubevirt_dialogs_template.yaml
@@ -184,8 +184,8 @@
           :required_method:
           - :validate_vm_name
           - :validate_regex
-          :required_regex: !ruby/regexp /\A[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\Z/
-          :required_regex_fail_details: The name must be composed of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+          :required_regex: !ruby/regexp /\A(?!-)[a-z0-9-]{1,63}(?<!-)\Z/
+          :required_regex_fail_details: The name must be composed of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character.
           :required: true
           :notes:
           :display: :edit


### PR DESCRIPTION
The VM name should be restricted by the following limitations:
1. Only alphanumeric characters or '-'.
2. First and last characters must be alphanumeric.
3. Up to 63 characters.

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/85