### PR TITLE
Implement authentication_status_ok? method

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -111,6 +111,10 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
     virt_supported
   end
 
+  def authentication_status_ok?(type = :kubevirt)
+    authentication_best_fit(type).try(:status) == "Valid"
+  end
+
   #
   # The ManageIQ core calls this method whenever a connection to the server is needed.
   #


### PR DESCRIPTION
The UI expects each provider to report its status.
Since kubevirt uses its own token, it might be valid while the container
provider is invalid.

That causes the default_auth_status in the UI [1] to report a failed
status when editing the kubevirt provider as an infrastructure provider,
since it refers to the status of the parent container manager. As a
result of that failure, the dialog cannot be saved.

For that purpose, the delegated call to authentication_status_ok? should
be implemented on the kubevirt provider side.

[1] https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/ems_common_angular.rb#L861

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/71