### PR TITLE
Implement auth methods

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -115,6 +115,14 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
     authentication_best_fit(type).try(:status) == "Valid"
   end
 
+  def authentication_for_providers
+    authentications.where(:authtype => :kubevirt)
+  end
+
+  def default_auth_status_ok?
+    true
+  end
+
   #
   # The ManageIQ core calls this method whenever a connection to the server is needed.
   #


### PR DESCRIPTION
The default_auth_status is being used by the UI to detect the validity
of the provider. For kubevirt, the default auth_status refers to the
parent provider, while kubevirt auth_status is detected by the :kubevirt
auth_type.

For that purpose, there is a need to report always 'true' for the
'default_auth_status', so the kubevirt provider can be edited when being
accessed as an infra provider.

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/71