### PR TITLE
Use UNKNOWN store type for kubevirt storage

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -59,7 +59,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManagerRefresh::Invento
     storage_object.ems_ref = STORAGE_ID
     storage_object.ems_ref_obj = STORAGE_ID
     storage_object.name = collector.manager.name
-    storage_object.store_type = 'KUBERNETES'
+    storage_object.store_type = 'UNKNOWN'
     storage_object.total_space = 0
     storage_object.free_space = 0
     storage_object.uncommitted = 0

--- a/spec/models/manageiq/providers/kubevirt/inventory/full_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/full_refresh_spec.rb
@@ -161,6 +161,6 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser::FullRefresh do
     expect(storage.ems_ref).to eq('0')
     expect(storage.ems_ref_obj).to eq('0')
     expect(storage.name).to eq('mykubevirt')
-    expect(storage.store_type).to eq('KUBERNETES')
+    expect(storage.store_type).to eq('UNKNOWN')
   end
 end

--- a/spec/models/manageiq/providers/kubevirt/inventory/partial_target_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/partial_target_refresh_spec.rb
@@ -167,6 +167,6 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser::PartialTargetRefresh 
     expect(storage.ems_ref).to eq('0')
     expect(storage.ems_ref_obj).to eq('0')
     expect(storage.name).to eq('mykubevirt')
-    expect(storage.store_type).to eq('KUBERNETES')
+    expect(storage.store_type).to eq('UNKNOWN')
   end
 end


### PR DESCRIPTION
Since there is no storage types support for kubevirt, the UNKNOWN
store type should be used for the meantime.

![selection_607](https://user-images.githubusercontent.com/316242/41600033-7a9c065c-73dd-11e8-861b-24017ef2800c.png)