### PR TITLE
Reduce kubevirt authentication to kubevirt provider only

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -115,6 +115,10 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
     authentication_best_fit(type).try(:status) == "Valid"
   end
 
+  def authentication_for_providers
+    authentications.where(:authtype => :kubevirt)
+  end
+
   #
   # The ManageIQ core calls this method whenever a connection to the server is needed.
   #


### PR DESCRIPTION
This PR is complementary to https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/260

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/35 