### PR TITLE
Do not fail on before_exit

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -60,11 +60,11 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
   def before_exit(_message, _exit_code)
     # Ask the watch threads to finish, and wait for them:
     stop_watches
-    @watchers.each(&:join)
+    @watchers&.each(&:join)
 
     # Ask the processor thread to finish, and wait for it:
-    @queue.push(nil)
-    @processor.join
+    @queue&.push(nil)
+    @processor&.join
   end
 
   private
@@ -226,7 +226,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
   # Stop all the watches
   #
   def stop_watches
-    @finish.value = true
-    @watches.each(&:finish)
+    @finish&.value = true
+    @watches&.each(&:finish)
   end
 end


### PR DESCRIPTION
When starting the MIQ server with an invalid kubevirt token, there are
no watchers were set and the queue to process them wasn't initialized.
Therefore, in order to get the failure reason properly without
misleading errors, we shouldn't fail for uninitialized variables.