### PR TITLE
Replaces missing Inventory::Builder in refresh runner

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -91,13 +91,14 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
   # Performs a full refresh.
   #
   def full_refresh
-    # Create and populate the collector, persister and parser:
-    persister = ManageIQ::Providers::Kubevirt::Inventory::Persister.new(manager, manager)
-    parser, collector = ManageIQ::Providers::Kubevirt::Builder.build_full(manager, persister)
+    # Create and populate the collector, persister and parser
+    # and parse inventories
+    inventory = ManageIQ::Providers::Kubevirt::Inventory.build(manager, nil)
+    collector = inventory.collector
+    persister = inventory.persister
 
-    # execute parse and persist:
-    parser.parse
-    persister.persist!
+    # execute persist:
+    persister&.persist!
 
     # Update the memory:
     memory.add_list_version(:nodes, collector.nodes.resource_version)


### PR DESCRIPTION
Full refresh fails in `ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner`.

`ManageIQ::Providers::Inventory.build` should be used instead of `ManageIQ::Providers::Inventory::Kubevirt::Builder.build_full`, which was removed.

---

Fixes **BZ** https://bugzilla.redhat.com/show_bug.cgi?id=1632131

caused by PR: https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/115

---

Steps to reproduce:

Click on Refresh on Kubevirt provider