### PR TITLE
Fix image name

### DIFF
--- a/manifests/working-template.yml
+++ b/manifests/working-template.yml
@@ -50,7 +50,7 @@ objects:
         volumes:
         - name: registryvolume
           registryDisk:
-            image: registry:5000/kubevirt/fedora-cloud-registry-disk-demo:devel
+            image: kubevirt/fedora-cloud-registry-disk-demo:latest
         - cloudInitNoCloud:
             userData: |-
               #cloud-config


### PR DESCRIPTION
Current name rely on local registry which is not available everywhere.
Let's base our template on image available in quay.

Fixes: https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/123