### PR TITLE
refresh: Parser was never called

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -95,7 +95,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
     # and parse inventories
     inventory = ManageIQ::Providers::Kubevirt::Inventory.build(manager, nil)
     collector = inventory.collector
-    persister = inventory.persister
+    persister = inventory.parse
 
     # execute persist:
     persister&.persist!


### PR DESCRIPTION
With recent change [1] we introduced this regression where we stopped calling
parser. This PR fixes the issue.

Fixes: https://bugzilla.redhat.com/1649629

[1] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/117