### PR TITLE
Remove duplicated persister shared_options

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/persister.rb
@@ -131,11 +131,4 @@ class ManageIQ::Providers::Kubevirt::Inventory::Persister < ManageIQ::Providers:
   def strategy
     :local_db_find_missing_references
   end
-
-  def shared_options
-    {
-      :strategy => strategy,
-      :parent   => manager.presence,
-    }
-  end
 end


### PR DESCRIPTION
The shared_options were duplicated from the base persister