### PR TITLE
Fix deprecation on status attributes

### DIFF
--- a/spec/factories/template_kubevirt.rb
+++ b/spec/factories/template_kubevirt.rb
@@ -1,3 +1,3 @@
 FactoryBot.define do
-  factory(:template_kubevirt, :class => "ManageIQ::Providers::Kubevirt::InfraManager::Template", :parent => :template_infra) { vendor "kubevirt" }
+  factory(:template_kubevirt, :class => "ManageIQ::Providers::Kubevirt::InfraManager::Template", :parent => :template_infra) { vendor { "kubevirt" } }
 end

--- a/spec/factories/vm_kubevirt.rb
+++ b/spec/factories/vm_kubevirt.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :vm_kubevirt, :class => "ManageIQ::Providers::Kubevirt::InfraManager::Vm", :parent => :vm_infra do
-    vendor          "kubevirt"
-    raw_power_state "up"
+    vendor          { "kubevirt" }
+    raw_power_state { "up" }
   end
 end


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

raw_power_state { "up" }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop
--require rubocop-rspec
--only FactoryBot/AttributeDefinedStatically
--auto-correct