### PR TITLE
Remove gettext initializer

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_Kubevirt',
-  ManageIQ::Providers::Kubevirt::Engine.root.join('locale').to_s,
-  :po
-)


### PR DESCRIPTION
We no longer need to initialize plugin's own gettext catalog (since it has none).