### PR TITLE
update_attributes deprecation

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -106,11 +106,11 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
     memory.add_list_version(:vm_instances, collector.vm_instances.resource_version)
     memory.add_list_version(:templates, collector.templates.resource_version)
 
-    manager.update_attributes(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
+    manager.update(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
   rescue StandardError => error
     _log.error('Full refresh failed.')
     _log.log_backtrace(error)
-    manager.update_attributes(:last_refresh_error => error.to_s, :last_refresh_date => Time.now.utc)
+    manager.update(:last_refresh_error => error.to_s, :last_refresh_date => Time.now.utc)
   end
 
   #
@@ -175,11 +175,11 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
       memory.add_notice(notice)
     end
 
-    manager.update_attributes(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
+    manager.update(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
   rescue StandardError => error
     _log.error('Partial refresh failed.')
     _log.log_backtrace(error)
-    manager.update_attributes(:last_refresh_error => error.to_s, :last_refresh_date => Time.now.utc)
+    manager.update(:last_refresh_error => error.to_s, :last_refresh_date => Time.now.utc)
   end
 
   #


### PR DESCRIPTION
update_attributes and update_attributes! are deprecated starting in Rails 6

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links.