### PR TITLE
Delay load fog-kubevirt until doing operations

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-require 'fog/kubevirt'
-
 #
 # This class hides the fact that when connecting to KubeVirt we need to use different API servers:
 # one for the standard Kubernetes API and another one for the KubeVirt API.
@@ -33,6 +30,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Connection
   # @option opts [String] :token The authentication token.
   #
   def initialize(opts = {})
+    require 'fog/kubevirt'
     # Get options and assign default values:
     @namespace = opts[:namespace] || 'default'
 

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'fog/kubevirt'
-
 module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations
   extend ActiveSupport::Concern
 
   include_concern 'Power'
 
   def raw_destroy
+    require 'fog/kubevirt'
     ext_management_system.with_provider_connection do |connection|
       # Retrieve the details of the virtual machine:
       begin

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -20,7 +20,6 @@
 #
 class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   include Vmdb::Logging
-  require 'fog/kubevirt'
 
   protected
 
@@ -234,6 +233,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
   end
 
   def process_hardware(template_object, params, labels, domain)
+    require 'fog/kubevirt'
     hw_object = hw_collection.find_or_build(template_object)
     memory = default_value(params, 'MEMORY') || domain.dig(:resources, :requests, :memory)
     hw_object.memory_mb = ManageIQ::Providers::Kubevirt::MemoryCalculator.convert(memory, 'Mi')
@@ -267,6 +267,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
   end
 
   def process_os(template_object, labels, annotations)
+    require 'fog/kubevirt'
     os_object = vm_os_collection.find_or_build(template_object)
     os_object.product_name = labels&.dig(Fog::Compute::Kubevirt::Shared::OS_LABEL_SYMBOL)
     tags = annotations&.dig(:tags) || []


### PR DESCRIPTION
Note, autoload would be nice to use here but since you can only autoload from
the parent namespace, you'd have to use Fog.autoload ..., which loads Fog, making
it pointless to try to delay load things.