### PR TITLE
Update fog-kubevirt to newer version

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -35,12 +35,13 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Connection
     @namespace = opts[:namespace] || 'default'
 
     # create fog based connection
-    @conn = Fog::Compute.new(:provider           => 'kubevirt',
-                             :kubevirt_hostname  => opts[:host],
-                             :kubevirt_port      => opts[:port],
-                             :kubevirt_token     => opts[:token],
-                             :kubevirt_namespace => @namespace,
-                             :kubevirt_log       => $log)
+    @conn = Fog::Kubevirt::Compute.new(
+      :kubevirt_hostname  => opts[:host],
+      :kubevirt_port      => opts[:port],
+      :kubevirt_token     => opts[:token],
+      :kubevirt_namespace => @namespace,
+      :kubevirt_log       => $log
+    )
 
     # Nothing else is done here, as this method should never throw an exception, even if the
     # credentials are wrong.

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -234,13 +234,14 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
 
   def process_hardware(template_object, params, labels, domain)
     require 'fog/kubevirt'
+    require 'fog/kubevirt/compute/models/template'
     hw_object = hw_collection.find_or_build(template_object)
     memory = default_value(params, 'MEMORY') || domain.dig(:resources, :requests, :memory)
     hw_object.memory_mb = ManageIQ::Providers::Kubevirt::MemoryCalculator.convert(memory, 'Mi')
     cpu = default_value(params, 'CPU_CORES') || domain.dig(:cpu, :cores)
     hw_object.cpu_cores_per_socket = cpu
     hw_object.cpu_total_cores = cpu
-    hw_object.guest_os = labels&.dig(Fog::Compute::Kubevirt::Shared::OS_LABEL_SYMBOL)
+    hw_object.guest_os = labels&.dig(Fog::Kubevirt::Compute::Template::OS_LABEL_SYMBOL)
 
     # Add the inventory objects for the disk:
     process_disks(hw_object, domain)
@@ -268,8 +269,9 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
 
   def process_os(template_object, labels, annotations)
     require 'fog/kubevirt'
+    require 'fog/kubevirt/compute/models/template'
     os_object = vm_os_collection.find_or_build(template_object)
-    os_object.product_name = labels&.dig(Fog::Compute::Kubevirt::Shared::OS_LABEL_SYMBOL)
+    os_object.product_name = labels&.dig(Fog::Kubevirt::Compute::Template::OS_LABEL_SYMBOL)
     tags = annotations&.dig(:tags) || []
     os_object.product_type = if tags.include?("linux")
                                "linux"

--- a/manageiq-providers-kubevirt.gemspec
+++ b/manageiq-providers-kubevirt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency("fog-kubevirt", "~> 0.2.0")
+  s.add_runtime_dependency("fog-kubevirt", "~> 1.0")
   s.add_runtime_dependency("manageiq-providers-kubernetes", "~> 0.1.0")
 
   s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")


### PR DESCRIPTION
Allow for the use of a newer version of kubeclient by bumping fog-kubevirt