### PR TITLE
BigDecimal#initialize was removed in 2.0.0

### DIFF
--- a/app/models/manageiq/providers/kubevirt/memory_calculator.rb
+++ b/app/models/manageiq/providers/kubevirt/memory_calculator.rb
@@ -39,7 +39,7 @@ class ManageIQ::Providers::Kubevirt::MemoryCalculator
     from = match[:suffix]
 
     # Convert the value from string to big decimal to make sure that we don't loose precission:
-    value = BigDecimal.new(value)
+    value = BigDecimal(value)
 
     # Do the conversion:
     from_factor = scale_factor(from)


### PR DESCRIPTION
Move to BigDecimal(value) instead of BigDecimal.new(value) as this was removed and no longer works on recent rubies (https://github.com/ruby/bigdecimal/blob/master/CHANGES.md#200)

https://github.com/ManageIQ/manageiq/issues/19678