### PR TITLE
Convert `supports_#{op}?` to `supports?(op)`

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
@@ -23,16 +23,16 @@ class ManageIQ::Providers::Kubevirt::InfraManager::ProvisionWorkflow < MiqProvis
     ManageIQ::Providers::Kubevirt::InfraManager
   end
 
-  def supports_pxe?
-    get_value(@values[:provision_type]).to_s == 'pxe'
+  supports :pxe do
+    unsupported_reason_add(:pxe, _("PXE is not available for provisioning")) unless get_value(@values[:provision_type]).to_s == 'pxe'
   end
 
-  def supports_iso?
-    get_value(@values[:provision_type]).to_s == 'iso'
+  supports :iso do
+    unsupported_reason_add(:iso, _("ISO is not available for provisioning")) unless get_value(@values[:provision_type]).to_s == 'iso'
   end
 
-  def supports_native_clone?
-    get_value(@values[:provision_type]).to_s == 'native_clone'
+  supports :native_clone do
+    unsupported_reason_add(:native_clone, _("Native Clone is not available for provisioning")) unless get_value(@values[:provision_type]).to_s == 'native_clone'
   end
 
   def allowed_provision_types(_options = {})

--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
@@ -23,16 +23,16 @@ class ManageIQ::Providers::Kubevirt::InfraManager::ProvisionWorkflow < MiqProvis
     ManageIQ::Providers::Kubevirt::InfraManager
   end
 
-  supports :pxe do
-    unsupported_reason_add(:pxe, _("PXE is not available for provisioning")) unless get_value(@values[:provision_type]).to_s == 'pxe'
+  def supports_pxe?
+    get_value(@values[:provision_type]).to_s == 'pxe'
   end
 
-  supports :iso do
-    unsupported_reason_add(:iso, _("ISO is not available for provisioning")) unless get_value(@values[:provision_type]).to_s == 'iso'
+  def supports_iso?
+    get_value(@values[:provision_type]).to_s == 'iso'
   end
 
-  supports :native_clone do
-    unsupported_reason_add(:native_clone, _("Native Clone is not available for provisioning")) unless get_value(@values[:provision_type]).to_s == 'native_clone'
+  def supports_native_clone?
+    get_value(@values[:provision_type]).to_s == 'native_clone'
   end
 
   def allowed_provision_types(_options = {})

--- a/app/models/manageiq/providers/kubevirt/infra_manager/template.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/template.rb
@@ -17,7 +17,7 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
@@ -20,7 +20,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations
 
   included do
     supports :terminate do
-      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports?(:control)
     end
   end
 

--- a/spec/models/manageiq/providers/kubevirt/infra_manager/vm/operations_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/infra_manager/vm/operations_spec.rb
@@ -51,8 +51,8 @@ describe 'VM::Operations' do
     let(:vm_metadata) { double("vm_metadata", :namespace => "default") }
     let(:provider_vm) { double("provider_vm", :metadata => vm_metadata) }
 
-    it "supports_terminate?" do
-      expect(vm.supports_terminate?).to be_truthy
+    it "supports?(:terminate)" do
+      expect(vm.supports?(:terminate)).to be_truthy
     end
 
     context 'running vm' do


### PR DESCRIPTION
Additionally, convert method definitions such as

```ruby
def supports_port?
  true
end
```

to

```ruby
supports :port
```