### PR TITLE
Add pluggable provider secrets support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .rubocop-*
 /bundler.d/*
 !/bundler.d/.keep
+/config/secrets.yml
 /config/settings.local.yml
 /config/settings/*.local.yml
 /config/environments/*.local.yml

--- a/lib/manageiq/providers/kubevirt/engine.rb
+++ b/lib/manageiq/providers/kubevirt/engine.rb
@@ -6,6 +6,11 @@ module ManageIQ
 
         config.autoload_paths << root.join('lib').to_s
 
+        initializer :append_secrets do |app|
+          app.config.paths["config/secrets"] << root.join("config", "secrets.defaults.yml").to_s
+          app.config.paths["config/secrets"] << root.join("config", "secrets.yml").to_s
+        end
+
         def self.vmdb_plugin?
           true
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,9 @@ require "manageiq-providers-kubevirt"
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::Kubevirt::Engine.root, 'spec/vcr_cassettes')
+
+  secrets = Rails.application.secrets
+  secrets.kubevirt&.each_key do |secret|
+    config.define_cassette_placeholder(secrets.kubevirt_defaults[secret]) { secrets.kubevirt[secret] }
+  end
 end


### PR DESCRIPTION
Kubevirt doesn't have VCR specs so I didn't add a default secrets file but this adds the callout in the Engine and spec_helper for it if needed in the future.

https://github.com/ManageIQ/manageiq/issues/21157