### PR TITLE
Fix KubeVirt endpoint verification

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -114,7 +114,8 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   end
 
   def self.verify_credentials(args)
-    !!raw_connect(args.dig("endpoints", "default")&.slice("server", "port", "token")&.symbolize_keys)
+    kubevirt = raw_connect(args.dig("endpoints", "default")&.slice("server", "port", "token")&.symbolize_keys)
+    kubevirt&.valid? && kubevirt&.virt_supported?
   end
 
   #
@@ -128,14 +129,11 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   #
   def self.raw_connect(opts)
     # Create the connection:
-    connection = Connection.new(
+    Connection.new(
       :host  => opts[:server],
       :port  => opts[:port],
       :token => ManageIQ::Password.try_decrypt(opts[:token])
     )
-
-    # Verify that the connection works:
-    connection.valid?
   end
 
   #


### PR DESCRIPTION
`connection.valid?` doesn't return the same connection which causes a later check for `#virt_supported?` to return `nil` when the connection actually does support virtualization.

The result was even with valid endpoint info and credentials the credential verification would always fail with "unknown error"

```
(byebug) kubevirt
#<ManageIQ::Providers::Kubevirt::InfraManager::Connection:0x0000559626830880 @namespace="default", ...
(byebug) kubevirt.valid?
#<Kubeclient::Resource kind="Namespace", apiVersion="v1", ...
(byebug) kubevirt.valid?.virt_supported? # This is essentially what https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/457/files#diff-1fe0d067134e4f6092c7cf36d13501a6d283dcc890e7279c0de4059af6a49de5L817 was doing
nil
```