### PR TITLE
Fix KubeVirt Refresh

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -34,13 +34,14 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
              :inverse_of  => :infra_manager
 
   delegate :authentication_check,
-          :authentication_for_summary,
-          :authentication_token,
-          :authentications,
-          :endpoints,
-          :zone,
-          :to        => :parent_manager,
-          :allow_nil => true
+           :authentication_for_summary,
+           :authentication_token,
+           :authentications,
+           :endpoints,
+           :default_endpoint,
+           :zone,
+           :to        => :parent_manager,
+           :allow_nil => true
 
   def self.hostname_required?
    false

--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -34,14 +34,14 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
              :inverse_of  => :infra_manager
 
   delegate :authentication_check,
-           :authentication_for_summary,
-           :authentication_token,
-           :authentications,
-           :endpoints,
-           :default_endpoint,
-           :zone,
-           :to        => :parent_manager,
-           :allow_nil => true
+          :authentication_for_summary,
+          :authentication_token,
+          :authentications,
+          :endpoints,
+          :default_endpoint,
+          :zone,
+          :to        => :parent_manager,
+          :allow_nil => true
 
   def self.hostname_required?
    false

--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresher.rb
@@ -18,27 +18,4 @@
 # This class is responsible for the inventory refresh process.
 #
 class ManageIQ::Providers::Kubevirt::InfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-  def collect_inventory_for_targets(ems, targets)
-    targets_with_data = targets.collect do |target|
-      _log.info("Filtering inventory for #{target.class} [#{target.name}] id: [#{target.id}]...")
-
-      data = ManageIQ::Providers::Kubevirt::Inventory.build(ems, target)
-
-      _log.info("Filtering inventory...Complete")
-      [target, data]
-    end
-
-    targets_with_data
-  end
-
-  def parse_targeted_inventory(ems, _target, inventory)
-    log_header = format_ems_for_logging(ems)
-    _log.debug("#{log_header} Parsing inventory...")
-    hashes, = Benchmark.realtime_block(:parse_inventory) do
-      inventory.inventory_collections
-    end
-    _log.debug("#{log_header} Parsing inventory...Complete")
-
-    hashes
-  end
 end

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -81,7 +81,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     host_object.hostname = object.hostname
     host_object.ipaddress = object.ip_address
     host_object.name = name
-    host_object.type = ::Host.name
+    host_object.type = 'ManageIQ::Providers::Kubevirt::InfraManager::Host'
     host_object.uid_ems = uid
     host_object.vmm_product = ManageIQ::Providers::Kubevirt::Constants::PRODUCT
     host_object.vmm_vendor = ManageIQ::Providers::Kubevirt::Constants::VENDOR
@@ -157,7 +157,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     vm_object.storage = storage_object
     vm_object.storages = [storage_object]
     vm_object.template = false
-    vm_object.type = ::ManageIQ::Providers::Kubevirt::InfraManager::Vm.name
+    vm_object.type = 'ManageIQ::Providers::Kubevirt::InfraManager::Vm'
     vm_object.uid_ems = uid
     vm_object.vendor = ManageIQ::Providers::Kubevirt::Constants::VENDOR
     vm_object.location = 'unknown'
@@ -208,7 +208,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     template_object.name = object.name
     template_object.raw_power_state = 'never'
     template_object.template = true
-    template_object.type = ::ManageIQ::Providers::Kubevirt::InfraManager::Template.name
+    template_object.type = 'ManageIQ::Providers::Kubevirt::InfraManager::Template'
     template_object.uid_ems = uid
     template_object.vendor = ManageIQ::Providers::Kubevirt::Constants::VENDOR
     template_object.location = 'unknown'

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :ems_kubevirt,
+          :aliases => ["manageiq/providers/kubevirt/infra_manager"],
+          :class   => "ManageIQ::Providers::Kubevirt::InfraManager",
+          :parent  => :ems_infra do
+    parent_manager { FactoryBot.create(:ems_container) }
+  end
+end

--- a/spec/models/manageiq/providers/kubevirt/inventory/full_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/full_refresh_spec.rb
@@ -28,6 +28,7 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser::FullRefresh do
       inventory.parse
 
       persister = inventory.persister
+      persister.persist!
 
       # Check that the built-in objects have been added:
       check_builtin_clusters(persister)
@@ -65,12 +66,9 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser::FullRefresh do
   # @return [Object] The manager object.
   #
   def create_manager(file_name)
-    manager = double
-    allow(manager).to receive(:name).and_return('mykubevirt')
-    allow(manager).to receive(:id).and_return(0)
-    allow(manager).to receive(:with_provider_connection).and_yield(json_data(file_name))
-    allow(manager.class).to receive(:ems_type).and_return(::ManageIQ::Providers::Kubevirt::Constants::VENDOR)
-    manager
+    FactoryBot.create(:ems_kubevirt, :name => "mykubevirt").tap do |manager|
+      allow(manager).to receive(:with_provider_connection).and_yield(json_data(file_name))
+    end
   end
 
   #

--- a/spec/models/manageiq/providers/kubevirt/inventory/full_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/full_refresh_spec.rb
@@ -48,7 +48,7 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser::FullRefresh do
       expect(host.hostname).to eq('mynode.local')
       expect(host.ipaddress).to eq('192.168.122.40')
       expect(host.name).to eq('mynode')
-      expect(host.type).to eq('Host')
+      expect(host.type).to eq('ManageIQ::Providers::Kubevirt::InfraManager::Host')
       expect(host.uid_ems).to eq('d88c7af6-de6a-11e7-8725-52540080f1d2')
       expect(host.vmm_product).to eq('KubeVirt')
       expect(host.vmm_vendor).to eq('kubevirt')

--- a/spec/models/manageiq/providers/kubevirt/inventory/full_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/full_refresh_spec.rb
@@ -19,57 +19,57 @@ require 'recursive_open_struct'
 
 describe ManageIQ::Providers::Kubevirt::Inventory::Parser::FullRefresh do
   describe '#parse' do
+    let(:ems) do
+      FactoryBot.create(:ems_kubevirt, :name => "mykubevirt").tap do |manager|
+        allow(manager).to receive(:with_provider_connection).and_yield(json_data('one_node'))
+      end
+    end
+
     it 'works correctly with one node' do
-      # Run the parser:
-      manager = create_manager('one_node')
-      inventory = ManageIQ::Providers::Kubevirt::Inventory.build(manager, nil)
+      2.times do
+        EmsRefresh.refresh(ems)
 
-      expect(inventory.parsers.first.class).to eq(described_class)
-      inventory.parse
+        expect(ems.hosts.count).to eq(1)
+        expect(ems.clusters.count).to eq(1)
+        expect(ems.storages.count).to eq(1)
 
-      persister = inventory.persister
-      persister.persist!
+        # Check that the first host has been created:
+        host = ems.hosts.find_by(:ems_ref => "d88c7af6-de6a-11e7-8725-52540080f1d2")
+        expect(host).to have_attributes(
+          :connection_state => "connected",
+          :ems_ref          => "d88c7af6-de6a-11e7-8725-52540080f1d2",
+          :hostname         => "mynode.local",
+          :ipaddress        => "192.168.122.40",
+          :name             => "mynode",
+          :type             => "ManageIQ::Providers::Kubevirt::InfraManager::Host",
+          :uid_ems          => "d88c7af6-de6a-11e7-8725-52540080f1d2",
+          :vmm_product      => "KubeVirt",
+          :vmm_vendor       => "kubevirt",
+          :vmm_version      => "0.1.0",
+          :ems_cluster      => ems.ems_clusters.find_by(:ems_ref => "0")
+        )
 
-      # Check that the built-in objects have been added:
-      check_builtin_clusters(persister)
-      check_builtin_storages(persister)
+        cluster = ems.ems_clusters.find_by(:ems_ref => "0")
+        expect(cluster).to have_attributes(
+          :ems_ref => "0",
+          :name    => "mykubevirt",
+          :uid_ems => "0",
+          :type    => "ManageIQ::Providers::Kubevirt::InfraManager::Cluster"
+        )
 
-      # Check that the collection of hosts has been created:
-      hosts_collection = persister.collections[:hosts]
-      expect(hosts_collection).to_not be_nil
-      hosts_data = hosts_collection.data
-      expect(hosts_data).to_not be_nil
-      expect(hosts_data.length).to eq(1)
-
-      # Check that the first host has been created:
-      host = hosts_data.first
-      expect(host).to_not be_nil
-      expect(host.connection_state).to eq('connected')
-      expect(host.ems_ref).to eq('d88c7af6-de6a-11e7-8725-52540080f1d2')
-      expect(host.hostname).to eq('mynode.local')
-      expect(host.ipaddress).to eq('192.168.122.40')
-      expect(host.name).to eq('mynode')
-      expect(host.type).to eq('ManageIQ::Providers::Kubevirt::InfraManager::Host')
-      expect(host.uid_ems).to eq('d88c7af6-de6a-11e7-8725-52540080f1d2')
-      expect(host.vmm_product).to eq('KubeVirt')
-      expect(host.vmm_vendor).to eq('kubevirt')
-      expect(host.vmm_version).to eq('0.1.0')
-      expect(host.ems_cluster).to_not be_nil
+        storage = ems.storages.find_by(:ems_ref => "0")
+        expect(storage).to have_attributes(
+          :name        => "mykubevirt",
+          :total_space => 0,
+          :free_space  => 0,
+          :ems_ref     => "0",
+          :type        => "ManageIQ::Providers::Kubevirt::InfraManager::Storage"
+        )
+      end
     end
   end
 
   private
-
-  #
-  # Creates a manager double.
-  #
-  # @return [Object] The manager object.
-  #
-  def create_manager(file_name)
-    FactoryBot.create(:ems_kubevirt, :name => "mykubevirt").tap do |manager|
-      allow(manager).to receive(:with_provider_connection).and_yield(json_data(file_name))
-    end
-  end
 
   #
   # Creates a collector data from a JSON file. The file should be in the `spec/fixtures/files/collectors`


### PR DESCRIPTION
The KubeVirt specs don't appear to be exercising the refresh well enough, refreshing against a live provider results in three different issues:
1. Listing templates fails (https://github.com/fog/fog-kubevirt/pull/149)
2. Kubevirt::InfraManager::Refresher overrides are out of date, cause save_inventory to fail
3. InventoryObject.type being hard-coded to ::Host, not subclassed under Kubevirt::InfraManager

WIP pending appropriate specs that would have caught these