### PR TITLE
Bump kubevirt to 1.3.5 for openshift v4 fix

### DIFF
--- a/manageiq-providers-kubevirt.gemspec
+++ b/manageiq-providers-kubevirt.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fog-kubevirt",                  "~> 1.0"
+  spec.add_dependency "fog-kubevirt",                  "~> 1.0", ">= 1.3.5"
   spec.add_dependency "manageiq-providers-kubernetes", "~> 0.1.0"
 
   spec.add_development_dependency "manageiq-style"


### PR DESCRIPTION
The fog-kubevirt templates call was still hitting the old `/oapi` endpoint, fixed by https://github.com/fog/fog-kubevirt/pull/149