### PR TITLE
Collect kubevirt resources across all namespaces

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -131,9 +131,10 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   def self.raw_connect(opts)
     # Create the connection:
     Connection.new(
-      :host  => opts[:server],
-      :port  => opts[:port],
-      :token => ManageIQ::Password.try_decrypt(opts[:token])
+      :host      => opts[:server],
+      :port      => opts[:port],
+      :token     => ManageIQ::Password.try_decrypt(opts[:token]),
+      :namespace => ""
     )
   end
 
@@ -191,9 +192,10 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
     # Create and return the connection:
     endpoint = default_endpoint
     self.class::Connection.new(
-      :host  => endpoint.hostname,
-      :port  => endpoint.port,
-      :token => token,
+      :host      => endpoint.hostname,
+      :port      => endpoint.port,
+      :token     => token,
+      :namespace => ""
     )
   end
 

--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -134,7 +134,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
       :host      => opts[:server],
       :port      => opts[:port],
       :token     => ManageIQ::Password.try_decrypt(opts[:token]),
-      :namespace => ""
+      :namespace => "" # Collect resources across all namespaces
     )
   end
 

--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -31,15 +31,12 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Connection
   #
   def initialize(opts = {})
     require 'fog/kubevirt'
-    # Get options and assign default values:
-    @namespace = opts[:namespace] || 'default'
-
     # create fog based connection
     @conn = Fog::Kubevirt::Compute.new(
       :kubevirt_hostname  => opts[:host],
       :kubevirt_port      => opts[:port],
       :kubevirt_token     => opts[:token],
-      :kubevirt_namespace => @namespace,
+      :kubevirt_namespace => opts[:namespace] || 'default',
       :kubevirt_log       => $log
     )
 
@@ -171,8 +168,8 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Connection
   #
   # @param name [String] The name of the virtual machine to delete.
   #
-  def delete_vm_instance(name)
-    @conn.vminstances.destroy(name, @namespace)
+  def delete_vm_instance(name, namespace)
+    @conn.vminstances.destroy(name, namespace)
   end
 
   #

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
@@ -36,7 +36,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations
       end
 
       # delete vm instance
-      connection.delete_vm_instance(name) unless vm_instance.nil?
+      connection.delete_vm_instance(name, location) unless vm_instance.nil?
     end
   end
 end

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -112,7 +112,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
 
   def process_vm(object)
     # Process the domain:
-    vm_object = process_domain(object.memory, object.cpu_cores, object.uid, object.name)
+    vm_object = process_domain(object.namespace, object.memory, object.cpu_cores, object.uid, object.name)
 
     # Add the inventory object for the OperatingSystem
     process_os(vm_object, object.labels, object.annotations)
@@ -140,13 +140,13 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     end
 
     # Process the domain:
-    vm_object = process_domain(object.memory, object.cpu_cores, uid, name)
+    vm_object = process_domain(object.namespace, object.memory, object.cpu_cores, uid, name)
     process_status(vm_object, object.ip_address, object.node_name)
 
     vm_object.raw_power_state = object.status
   end
 
-  def process_domain(memory, cores, uid, name)
+  def process_domain(namespace, memory, cores, uid, name)
     # Find the storage:
     storage_object = storage_collection.lazy_find(STORAGE_ID)
     # Create the inventory object for the virtual machine:
@@ -160,7 +160,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     vm_object.type = 'ManageIQ::Providers::Kubevirt::InfraManager::Vm'
     vm_object.uid_ems = uid
     vm_object.vendor = ManageIQ::Providers::Kubevirt::Constants::VENDOR
-    vm_object.location = 'unknown'
+    vm_object.location = namespace
 
     # Create the inventory object for the hardware:
     hw_object = hw_collection.find_or_build(vm_object)

--- a/spec/models/manageiq/providers/kubevirt/inventory/parse_vm_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/parse_vm_spec.rb
@@ -49,6 +49,7 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
       source = double(
         :uid        => "9f3a8f56-1bc8-11e8-a746-001a4a23138b",
         :name       => "demo-vm",
+        :namespace  => "my-project",
         :memory     => "64M",
         :cpu_cores  => "2",
         :ip_address => "10.128.0.18",
@@ -65,7 +66,7 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
         :uid_ems          => "9f3a8f56-1bc8-11e8-a746-001a4a23138b",
         :vendor           => ManageIQ::Providers::Kubevirt::Constants::VENDOR,
         :power_state      => "on",
-        :location         => "unknown",
+        :location         => "my-project",
         :connection_state => "connected",
       )
 


### PR DESCRIPTION
fog-kubevirt has ` @namespace = options[:kubevirt_namespace] || 'default'` so we cannot simply leave this parameter out for now, but `""` has the same effect as leaving it blank

TODO:
- [x] Save the namespace with the vm / host objects
- [x] Update operations to pass the namespace in