### PR TITLE
Don't rely on rails magic to find fixtures, be explicit

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,3 +17,7 @@ VCR.configure do |config|
     config.define_cassette_placeholder(secrets.kubevirt_defaults[secret]) { secrets.kubevirt[secret] }
   end
 end
+
+RSpec.configure do |config|
+  config.file_fixture_path = ManageIQ::Providers::Kubevirt::Engine.root.join("spec/fixtures/files")
+end


### PR DESCRIPTION
As of https://github.com/ManageIQ/manageiq/pull/22039
core now specifies the fixture path so we need to be explicit when running
these tests.