### PR TITLE
Update safe_load calls to work with psych 3/4

### DIFF
--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -7,6 +7,6 @@ module FileHelpers
 
   def unprocessed_hash(file)
     data = file_fixture(file).read
-    YAML.safe_load(data, [Symbol])
+    YAML.safe_load(data, :permitted_classes => [Symbol])
   end
 end


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/22696

Keep compatibility with psych 3.1+ since permitted_classes and aliases were added as keyword arguments to safe_load.

Note, psych 4 changed the interface to drop support with positional arguments for the permitted_classes. Now, we must explicitly specify them using kwargs.