### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -1,15 +1,4 @@
 class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraManager
-  require_nested :Cluster
-  require_nested :Connection
-  require_nested :Host
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :Storage
-  require_nested :Template
-  require_nested :Vm
-
   ENDPOINT_ROLE = :kubevirt
 
   belongs_to :parent_manager,

--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::Provision < MiqProvision
-  include_concern 'Cloning'
-  include_concern 'StateMachine'
+  include Cloning
+  include StateMachine
 
   #
   # The ManageIQ core calls this method during the provision workflow to get the name of the object that is being

--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
-  include_concern 'Operations'
+  include Operations
 
   POWER_STATES = {
     'Running'    => 'on',

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
@@ -1,7 +1,6 @@
 module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'Power'
+  include Power
 
   included do
     supports :terminate do

--- a/app/models/manageiq/providers/kubevirt/inventory.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Kubevirt::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   def self.persister_class_for(_ems, _target)
     ManageIQ::Providers::Kubevirt::Inventory::Persister
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854