### PR TITLE
drop unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/template.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/template.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
+      ext_management_system.unsupported_reason(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('not connected to ems'))
+      _('not connected to ems')
     end
   end
 

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
@@ -3,9 +3,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations
   include Power
 
   included do
-    supports :terminate do
-      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports?(:control)
-    end
+    supports(:terminate) { unsupported_reason(:control) }
   end
 
   def raw_destroy


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
