### PR TITLE
Fix parent_manager class to point to Kubernetes::ContainerManager

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
 
   belongs_to :parent_manager,
              :foreign_key => :parent_ems_id,
-             :class_name  => "ManageIQ::Providers::ContainerManager",
+             :class_name  => "ManageIQ::Providers::Kubernetes::ContainerManager",
              :inverse_of  => :infra_manager
 
   delegate :authentication_check,

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
           :aliases => ["manageiq/providers/kubevirt/infra_manager"],
           :class   => "ManageIQ::Providers::Kubevirt::InfraManager",
           :parent  => :ems_infra do
-    parent_manager { FactoryBot.create(:ems_container) }
+    parent_manager { FactoryBot.create(:ems_kubernetes) }
   end
 end


### PR DESCRIPTION
Required for:
* https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/518

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
