### PR TITLE
Add catalog support for KubeVirt

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -23,6 +23,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   #
   # This is the list of features that this provider supports:
   #
+  supports :catalog
   supports :provisioning
 
   #
@@ -41,6 +42,10 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   #
   def self.description
     @description ||= ManageIQ::Providers::Kubevirt::Constants::PRODUCT
+  end
+
+  def self.catalog_types
+    {"kubevirt" => N_("OpenShift Virtualization / KubeVirt")}
   end
 
   def self.params_for_create


### PR DESCRIPTION
I'm working on deploying kubevirt/osv on my crc cluster for a live test, but for now it looks like the catalog item dialog uses the normal provisioning dialogs for the request which is great.

![image](https://github.com/user-attachments/assets/9475b1cc-ad36-4f71-b733-e47f58e24312)
![image](https://github.com/user-attachments/assets/f85cece3-289a-4c8a-817f-2a95c7cd3130)
![image](https://github.com/user-attachments/assets/673b1194-0b6f-405d-981b-b2cc00ae157d)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
