### PR TITLE
Fix parent_manager class name

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -3,8 +3,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
 
   belongs_to :parent_manager,
              :foreign_key => :parent_ems_id,
-             :class_name  => "ManageIQ::Providers::Kubernetes::ContainerManager",
-             :inverse_of  => :infra_manager
+             :class_name  => "ManageIQ::Providers::ContainerManager"
 
   delegate :authentication_check,
           :authentication_for_summary,


### PR DESCRIPTION
The parent_manager class had Kubernetes::ContainerManager specified which would result in parent_manager being nil when kubevirt was added to an Openshift::ContainerManager due to ActAsStiLeafClass.

Since the base ContainerManager doesn't have an infra_manager we have to drop the inverse_of.

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/239
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
