### PR TITLE
Fix parser exception when memory value is missing

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -148,7 +148,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
 
     # Create the inventory object for the hardware:
     hw_object = hw_collection.find_or_build(vm_object)
-    hw_object.memory_mb = parse_quantity(memory) / 1.megabytes.to_f
+    hw_object.memory_mb = parse_quantity(memory) / 1.megabytes.to_f if memory
     hw_object.cpu_cores_per_socket = cores
     hw_object.cpu_total_cores = cores
 
@@ -231,7 +231,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     require 'fog/kubevirt/compute/models/template'
     hw_object = hw_collection.find_or_build(template_object)
     memory = default_value(params, 'MEMORY') || domain.dig(:resources, :requests, :memory)
-    hw_object.memory_mb = parse_quantity(memory) / 1.megabytes.to_f
+    hw_object.memory_mb = parse_quantity(memory) / 1.megabytes.to_f if memory
     cpu = default_value(params, 'CPU_CORES') || domain.dig(:cpu, :cores)
     hw_object.cpu_cores_per_socket = cpu
     hw_object.cpu_total_cores = cpu


### PR DESCRIPTION
```
[NoMethodError]: undefined method `/' for nil:NilClass
manageiq-providers-kubevirt/app/models/manageiq/providers/kubevirt/inventory/parser.rb:151:in `process_domain'
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
