### PR TITLE
Openshift Virtualization subclassing changes

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraManager
-  ENDPOINT_ROLE = :kubevirt
+  DEFAULT_AUTH_TYPE = :kubevirt
 
   belongs_to :parent_manager,
              :foreign_key => :parent_ems_id,
@@ -31,7 +31,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   # @return [String] The provider type.
   #
   def self.ems_type
-    @ems_type ||= ManageIQ::Providers::Kubevirt::Constants::VENDOR
+    @ems_type ||= vendor
   end
 
   #
@@ -40,11 +40,23 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   # @return [String] The provider description.
   #
   def self.description
-    @description ||= ManageIQ::Providers::Kubevirt::Constants::PRODUCT
+    @description ||= product_name
+  end
+
+  def self.vendor
+    ManageIQ::Providers::Kubevirt::Constants::VENDOR
+  end
+
+  def self.product_name
+    ManageIQ::Providers::Kubevirt::Constants::PRODUCT
+  end
+
+  def self.version
+    ManageIQ::Providers::Kubevirt::Constants::VERSION
   end
 
   def self.catalog_types
-    {"kubevirt" => N_("OpenShift Virtualization / KubeVirt")}
+    {"kubevirt" => N_("KubeVirt")}
   end
 
   def self.params_for_create
@@ -149,12 +161,12 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
     virt_supported
   end
 
-  def authentication_status_ok?(type = :kubevirt)
+  def authentication_status_ok?(type = default_authentication_type)
     authentication_best_fit(type).try(:status) == "Valid"
   end
 
   def authentication_for_providers
-    authentications.where(:authtype => :kubevirt)
+    authentications.where(:authtype => default_authentication_type)
   end
 
   #
@@ -164,7 +176,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   #
   def connect(opts = {})
     # Get the authentication token:
-    token = opts[:token] || authentication_token(:kubevirt)
+    token = opts[:token] || authentication_token(default_authentication_type)
 
     # Create and return the connection:
     endpoint = default_endpoint
@@ -181,7 +193,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
   end
 
   def default_authentication_type
-    ENDPOINT_ROLE
+    DEFAULT_AUTH_TYPE
   end
 
   #

--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -53,13 +53,17 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
 
   private
 
+  def provider_class
+    ManageIQ::Providers::Kubevirt
+  end
+
   #
   # Returns the reference to the manager.
   #
   # @return [ManageIQ::Providers::Kubevirt::InfraManager] The manager.
   #
   def manager
-    @manager ||= ManageIQ::Providers::Kubevirt::InfraManager.find(@cfg[:ems_id])
+    @manager ||= provider_class::InfraManager.find(@cfg[:ems_id])
   end
 
   #
@@ -68,7 +72,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
   # @return [ManageIQ::Providers::Kubevirt::RefreshMemory] The refresh memory.
   #
   def memory
-    @memory ||= ManageIQ::Providers::Kubevirt::RefreshMemory.new
+    @memory ||= provider_class::RefreshMemory.new
   end
 
   #
@@ -77,7 +81,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
   def full_refresh
     # Create and populate the collector, persister and parser
     # and parse inventories
-    inventory = ManageIQ::Providers::Kubevirt::Inventory.build(manager, nil)
+    inventory = provider_class::Inventory.build(manager, nil)
     collector = inventory.collector
     persister = inventory.parse
 
@@ -140,15 +144,15 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
     relevant.reverse!
 
     # Create and populate the collector:
-    collector = ManageIQ::Providers::Kubevirt::Inventory::Collector.new(manager, nil)
+    collector = provider_class::Inventory::Collector.new(manager, nil)
     collector.nodes = notices_of_kind(relevant, 'Node')
     collector.vms = notices_of_kind(relevant, 'VirtualMachine')
     collector.vm_instances = notices_of_kind(relevant, 'VirtualMachineInstance')
     collector.templates = notices_of_kind(relevant, 'VirtualMachineTemplate')
 
     # Create the parser and persister, wire them, and execute the persist:
-    persister = ManageIQ::Providers::Kubevirt::Inventory::Persister.new(manager, nil)
-    parser = ManageIQ::Providers::Kubevirt::Inventory::Parser::PartialRefresh.new
+    persister = provider_class::Inventory::Persister.new(manager, nil)
+    parser = provider_class::Inventory::Parser::PartialRefresh.new
     parser.collector = collector
     parser.persister = persister
     parser.parse

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -65,11 +65,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     host_object.hostname = object.hostname
     host_object.ipaddress = object.ip_address
     host_object.name = name
-    host_object.type = 'ManageIQ::Providers::Kubevirt::InfraManager::Host'
     host_object.uid_ems = uid
-    host_object.vmm_product = ManageIQ::Providers::Kubevirt::Constants::PRODUCT
-    host_object.vmm_vendor = ManageIQ::Providers::Kubevirt::Constants::VENDOR
-    host_object.vmm_version = ManageIQ::Providers::Kubevirt::Constants::VERSION
 
     # Add the inventory object for the operating system details:
     os_object = os_collection.find_or_build(host_object)
@@ -141,9 +137,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     vm_object.storage = storage_object
     vm_object.storages = [storage_object]
     vm_object.template = false
-    vm_object.type = 'ManageIQ::Providers::Kubevirt::InfraManager::Vm'
     vm_object.uid_ems = uid
-    vm_object.vendor = ManageIQ::Providers::Kubevirt::Constants::VENDOR
     vm_object.location = namespace
 
     # Create the inventory object for the hardware:
@@ -204,9 +198,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     template_object.name = object.name
     template_object.raw_power_state = 'never'
     template_object.template = true
-    template_object.type = 'ManageIQ::Providers::Kubevirt::InfraManager::Template'
     template_object.uid_ems = uid
-    template_object.vendor = ManageIQ::Providers::Kubevirt::Constants::VENDOR
     template_object.location = 'unknown'
 
     # Add the inventory object for the hardware:

--- a/app/models/manageiq/providers/kubevirt/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/persister.rb
@@ -17,6 +17,13 @@ class ManageIQ::Providers::Kubevirt::Inventory::Persister < ManageIQ::Providers:
         :manager_uuids => ids,
         :targeted      => targeted
       )
+
+      builder.add_default_values(
+        :type        => "#{manager.class}::Host",
+        :vmm_product => manager.class.product_name,
+        :vmm_vendor  => manager.class.vendor,
+        :vmm_version => manager.class.version
+      )
     end
   end
 
@@ -69,6 +76,11 @@ class ManageIQ::Providers::Kubevirt::Inventory::Persister < ManageIQ::Providers:
         :manager_uuids                => ids,
         :parent_inventory_collections => %i(vms)
       )
+
+      builder.add_default_values(
+        :type   => "#{manager.class}::Template",
+        :vendor => manager.class.vendor
+      )
     end
   end
 
@@ -86,6 +98,11 @@ class ManageIQ::Providers::Kubevirt::Inventory::Persister < ManageIQ::Providers:
       builder.add_properties(
         :targeted      => targeted,
         :manager_uuids => ids,
+      )
+
+      builder.add_default_values(
+        :type   => "#{manager.class}::Vm",
+        :vendor => manager.class.vendor
       )
     end
   end


### PR DESCRIPTION
- make use of `:kubevirt` default auth type
- remove mention of OSV from catalog type
- generalize parser 

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-openshift/pull/264

@miq-bot assign @agrare 
@miq-bot add_label enhancement
@miq-bot add_reviewer @agrare 