### PR TITLE
Fix Kubevirt client get resource by name calls

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -184,7 +184,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
       :host      => endpoint.hostname,
       :port      => endpoint.port,
       :token     => token,
-      :namespace => ""
+      :namespace => opts[:namespace] || ""
     )
   end
 

--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
@@ -28,7 +28,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Provision::Cloning
   def start_clone(options)
     # Retrieve the details of the source template:
     template = nil
-    source.with_provider_connection do |connection|
+    source.with_provider_connection(:namespace => source.location) do |connection|
       template = connection.template(source.name)
       template.clone(user_options(options))
 

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations
 
   def raw_destroy
     require 'fog/kubevirt'
-    ext_management_system.with_provider_connection do |connection|
+    ext_management_system.with_provider_connection(:namespace => location) do |connection|
       # Retrieve the details of the virtual machine:
       begin
         vm_instance = connection.vm_instance(name)

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/power.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations::Power
   def raw_start
-    ext_management_system.with_provider_connection do |connection|
+    ext_management_system.with_provider_connection(:namespace => location) do |connection|
       # Retrieve the details of the virtual machine:
       vm = connection.vm(name)
       vm.start
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations::Power
   end
 
   def raw_stop
-    ext_management_system.with_provider_connection do |connection|
+    ext_management_system.with_provider_connection(:namespace => location) do |connection|
       # Retrieve the details of the virtual machine:
       vm = connection.vm(name)
       vm.stop

--- a/app/models/manageiq/providers/kubevirt/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/collector.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Collector < ManageIQ::Providers:
     name = @target.name
     @nodes = {}
 
-    @manager.with_provider_connection do |connection|
+    @manager.with_provider_connection(:namespace => @target.location) do |connection|
       if @target.template?
         @templates = [connection.template(name)]
       else

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -199,7 +199,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     template_object.raw_power_state = 'never'
     template_object.template = true
     template_object.uid_ems = uid
-    template_object.location = 'unknown'
+    template_object.location = object.namespace
 
     # Add the inventory object for the hardware:
     process_hardware(template_object, object.parameters, object.labels, vm.dig(:spec, :template, :spec, :domain))

--- a/spec/fixtures/files/template-without-parameters.yml
+++ b/spec/fixtures/files/template-without-parameters.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Template
 metadata:
   name: template-without-parameters
+  namespace: default
   annotations:
     description: "OpenShift KubeVirt Cirros VM template"
     tags: "kubevirt,openshift,template,linux"

--- a/spec/models/manageiq/providers/kubevirt/inventory/parser_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/parser_spec.rb
@@ -37,7 +37,8 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
         :objects     => json.objects,
         :parameters  => json.parameters,
         :labels      => json.metadata.labels,
-        :annotations => json.metadata.annotations
+        :annotations => json.metadata.annotations,
+        :namespace   => json.metadata.namespace
       )
 
       parser.send(:process_template, source)
@@ -49,7 +50,7 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
         :uid_ems          => "7e6fb1ac-00ef-11e8-8840-525400b2cba8",
         :vendor           => ManageIQ::Providers::Kubevirt::Constants::VENDOR,
         :power_state      => "never",
-        :location         => "unknown",
+        :location         => "default",
         :connection_state => "connected",
       )
 
@@ -105,7 +106,8 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
         :objects     => json.objects,
         :parameters  => json.parameters,
         :labels      => json.metadata.labels,
-        :annotations => json.metadata.annotations
+        :annotations => json.metadata.annotations,
+        :namespace   => json.metadata.namespace
       )
 
       parser.send(:process_template, source)
@@ -156,7 +158,8 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
         :objects     => json.objects,
         :parameters  => json.parameters,
         :labels      => json.metadata.labels,
-        :annotations => json.metadata.annotations
+        :annotations => json.metadata.annotations,
+        :namespace   => json.metadata.namespace
       )
 
       parser.send(:process_template, source)
@@ -168,7 +171,7 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
         :uid_ems          => "7e6fb1ac-00ef-11e8-8840-525400b2cba8",
         :vendor           => ManageIQ::Providers::Kubevirt::Constants::VENDOR,
         :power_state      => "never",
-        :location         => "unknown",
+        :location         => "default",
         :connection_state => "connected",
       )
 


### PR DESCRIPTION
- `resource.get(name)` calls are namespace scoped
- since we use the catch-all namespace `""` when initializing the client https://github.com/ManageIQ/manageiq-providers-kubevirt/blob/master/app/models/manageiq/providers/kubevirt/infra_manager.rb#L126, this will work for `resource.all` calls but will not work for `resource.get(name)` calls i.e. https://github.com/fog/fog-kubevirt/blob/master/lib/fog/kubevirt/compute/requests/get_template.rb#L6 and will return a 404

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/241

@miq-bot assign @agrare 
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare 