### PR TITLE
Service Catalog Provisioning Support

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
@@ -51,6 +51,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Provision::Cloning
     merged_options = options.dup
     merged_options[:cpu_cores] = get_option(:cores_per_socket)
     merged_options[:memory] = get_option(:vm_memory)
+    merged_options[:cloud_user_password] = get_option(:root_password)
     merged_options.compact
   end
 end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::Kubevirt::InfraManager::ProvisionWorkflow < MiqProvis
     get_value(@values[:provision_type]).to_s == 'iso'
   end
 
+  def supports_customization_template?
+    true
+  end
+
   def supports_native_clone?
     get_value(@values[:provision_type]).to_s == 'native_clone'
   end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision_workflow.rb
@@ -29,8 +29,8 @@ class ManageIQ::Providers::Kubevirt::InfraManager::ProvisionWorkflow < MiqProvis
     }
   end
 
-  def dialog_name_from_automate(message = 'get_dialog_name')
-    super(message, {'platform' => 'kubevirt'})
+  def dialog_name_from_automate(message = 'get_dialog_name', extra_attrs = {'platform' => 'kubevirt'})
+    super(message, extra_attrs)
   end
 
   def update_field_visibility

--- a/content/miq_dialogs/miq_provision_kubevirt_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_kubevirt_dialogs_template.yaml
@@ -120,16 +120,11 @@
           :required: false
           :options:
             :include: []
-
             :order: []
-
             :single_select: []
-
             :exclude: []
-
           :display: :edit
           :required_tags: []
-
           :data_type: :integer
       :display: :show
       :field_order:
@@ -297,9 +292,19 @@
           :default: "1024"
           :data_type: :string
       :display: :show
+    :customize:
+      :description: Customize
+      :fields:
+        :root_password:
+          :description: Cloud User Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
   :dialog_order:
   - :requester
   - :purpose
   - :service
   - :hardware
+  - :customize
   - :schedule


### PR DESCRIPTION
- `:cloud_user_password` is a necessary parameter needed to provision and is used as the password to the `CloudInitNoCloud` volume found in the available templates:
```
      volumes:
      - dataVolume:
          name: kubevirt-catalog-test0010
        name: rootdisk
      - cloudInitNoCloud:
          userData: |-
            #cloud-config
            user: fedora
            password: ${CLOUD_USER_PASSWORD}
            chpasswd: { expire: False }
```
- fog-kubevirt replaces the env var with the option passed https://github.com/fog/fog-kubevirt/blob/master/lib/fog/kubevirt/compute/models/template.rb#L167-L180

Needed for:
- https://github.com/ManageIQ/manageiq-providers-openshift/pull/266

@miq-bot assign @agrare 
@miq-bot add_labels bug, radjabov/yes?
@miq-bot add_reviewer @agrare 