### PR TITLE
Move RefreshMemory under InfraManager

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_memory.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_memory.rb
@@ -8,7 +8,7 @@ require 'set'
 # Current implementation stores the data in memory and there is no need to make it presistent
 # since we run full refresh every time we start the worker and when watches expire.
 #
-class ManageIQ::Providers::Kubevirt::RefreshMemory
+class ManageIQ::Providers::Kubevirt::InfraManager::RefreshMemory
   #
   # Creates a new object to hold the refresh data for the manager with the given identifier.
   #

--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -57,13 +57,17 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
     ManageIQ::Providers::Kubevirt
   end
 
+  def manager_class
+    provider_class::InfraManager
+  end
+
   #
   # Returns the reference to the manager.
   #
   # @return [ManageIQ::Providers::Kubevirt::InfraManager] The manager.
   #
   def manager
-    @manager ||= provider_class::InfraManager.find(@cfg[:ems_id])
+    @manager ||= manager_class.find(@cfg[:ems_id])
   end
 
   #
@@ -72,7 +76,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
   # @return [ManageIQ::Providers::Kubevirt::RefreshMemory] The refresh memory.
   #
   def memory
-    @memory ||= provider_class::RefreshMemory.new
+    @memory ||= manager_class::RefreshMemory.new
   end
 
   #


### PR DESCRIPTION
Better support subclassed providers (aka Openshift) which have the Kubevirt InfraManager in the same vendor namespace as other manager types like a ContainerManager.

Related:
* https://github.com/ManageIQ/manageiq-providers-openshift/pull/268#discussion_r1775606753

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
