### PR TITLE
Kubevirt authentication status

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager.rb
@@ -161,8 +161,12 @@ class ManageIQ::Providers::Kubevirt::InfraManager < ManageIQ::Providers::InfraMa
     virt_supported
   end
 
+  def authentication_status(type = default_authentication_type)
+    authentication_best_fit(type).try(:status)
+  end
+
   def authentication_status_ok?(type = default_authentication_type)
-    authentication_best_fit(type).try(:status) == "Valid"
+    authentication_status(type) == "Valid"
   end
 
   def authentication_for_providers


### PR DESCRIPTION
Since the parent manager (k8s) has auth records for k8s and kubevirt, we need to specifically get the auth status for kubevirt

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/246

@miq-bot assign @agrare 
@miq-bot add_labels bug, radjabov/yes?
@miq-bot add_reviewer @agrare 