### PR TITLE
Add VM event_groups to settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,26 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
+        :addition:
+          :critical:
+            - VIRTUALMACHINE_CREATED
+            - VIRTUALMACHINEINSTANCE_CREATED
+            - VIRTUALMACHINE_SUCCESSFULCREATE
+            - VIRTUALMACHINEINSTANCE_SUCCESSFULCREATE
+        :status:
+          :critical:
+            - VIRTUALMACHINE_MIGRATED
+            - VIRTUALMACHINEINSTANCE_MIGRATED
+        :power:
+          :critical:
+            - VIRTUALMACHINE_STARTED
+            - VIRTUALMACHINEINSTANCE_STARTED
+            - VIRTUALMACHINE_SHUTTINGDOWN
+            - VIRTUALMACHINEINSTANCE_SHUTTINGDOWN
+        :deletion:
+          :critical:
+            - VIRTUALMACHINE_SUCCESSFULDELETE
+            - VIRTUALMACHINEINSTANCE_SUCCESSFULDELETE
 :workers:
   :worker_base:
     :event_catcher:


### PR DESCRIPTION
Adding the necessary events to event_groups to view from the timeline in UI
<img width="1437" alt="Screenshot 2024-11-18 at 4 07 04 PM" src="https://github.com/user-attachments/assets/214f2c84-2dbf-4d67-ac74-1f3919968656">

@miq-bot assign @agrare 
@miq-bot add_label enhancement
@miq-bot add_reviewer @agrare 