### PR TITLE
Persist VM with host

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -123,6 +123,8 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     vm_object = process_domain(object.namespace, object.memory, object.cpu_cores, uid, name)
     process_status(vm_object, object.ip_address, object.node_name)
 
+    vm_object.host = host_collection.lazy_find(object.node_name, :ref => :by_name)
+
     vm_object.raw_power_state = object.status
   end
 

--- a/app/models/manageiq/providers/kubevirt/inventory/persister.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/persister.rb
@@ -15,7 +15,8 @@ class ManageIQ::Providers::Kubevirt::Inventory::Persister < ManageIQ::Providers:
     add_collection(infra, :hosts) do |builder|
       builder.add_properties(
         :manager_uuids => ids,
-        :targeted      => targeted
+        :targeted      => targeted,
+        :secondary_refs => {:by_name => %i[name]}
       )
 
       builder.add_default_values(

--- a/spec/models/manageiq/providers/kubevirt/inventory/parse_vm_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/parse_vm_spec.rb
@@ -11,6 +11,10 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
       storage = FactoryBot.create(:storage)
       allow(storage_collection).to receive(:lazy_find).and_return(storage)
 
+      host_collection = double("host_collection")
+      host = FactoryBot.create(:host)
+      allow(host_collection).to receive(:lazy_find).and_return(host)
+
       hw_collection = double("hw_collection")
       hardware = FactoryBot.create(:hardware)
       allow(hw_collection).to receive(:find_or_build).and_return(hardware)
@@ -26,6 +30,7 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
 
       parser = described_class.new
       parser.instance_variable_set(:@storage_collection, storage_collection)
+      parser.instance_variable_set(:@host_collection, host_collection)
       parser.instance_variable_set(:@vm_collection, vm_collection)
       parser.instance_variable_set(:@hw_collection, hw_collection)
       parser.instance_variable_set(:@network_collection, network_collection)
@@ -53,6 +58,7 @@ describe ManageIQ::Providers::Kubevirt::Inventory::Parser do
         :location         => "my-project",
         :connection_state => "connected",
       )
+      expect(vm.host).to eq(host)
 
       net = vm.hardware.networks.first
       expect(net).to_not be_nil


### PR DESCRIPTION
Cherry picked from https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/260

In Kubevirt, hosts are the nodes on which the VMs are deployed. The uid is not available from the VM payload that is returned by the API and so we use the name and add a secondary ref

Needed for:
- [ ] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/260
- [ ] https://github.com/ManageIQ/manageiq-providers-openshift/pull/275

@miq-bot assign @agrare 
@miq-bot add_labels enhancement
@miq-bot add_reviewer @agrare 