### PR TITLE
Restart a Virtual Machine

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
@@ -14,6 +14,10 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Vm < ManageIQ::Providers::Inf
   supports :capture
   supports :snapshots
 
+  supports :reboot_guest do
+    _('The VM is not powered on') unless current_state == 'on'
+  end
+  supports :reset
   def self.calculate_power_state(raw)
     POWER_STATES[raw] || super
   end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
@@ -2,6 +2,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations
   extend ActiveSupport::Concern
   include Power
   include Snapshot
+  include Guest
 
   included do
     supports(:terminate) { unsupported_reason(:control) }

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/guest.rb
@@ -2,13 +2,11 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations::Guest
 
   def raw_reboot_guest
     kubevirt = ext_management_system.parent_manager.connect(:service => "kubernetes", :path => "/apis/subresources.kubevirt.io", :version => "v1")
-    #method need to call on this kubevirt to restart the vm
-
+    kubevirt.rest_client["namespaces/#{location}/virtualmachineinstances/#{name}/softreboot"].put({}.to_json, { 'Content-Type' => 'application/json' }.merge(kubevirt.get_headers))
   end
 
   def raw_reset
     kubevirt = ext_management_system.parent_manager.connect(:service => "kubernetes", :path => "/apis/subresources.kubevirt.io", :version => "v1")
-    #method need to call on this kubevirt to soft reboot the vm
-
+    kubevirt.rest_client["namespaces/#{location}/virtualmachines/#{name}/restart"].put({}.to_json, { 'Content-Type' => 'application/json' }.merge(kubevirt.get_headers))
   end
 end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/guest.rb
@@ -1,0 +1,14 @@
+module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations::Guest
+
+  def raw_reboot_guest
+    kubevirt = ext_management_system.parent_manager.connect(:service => "kubernetes", :path => "/apis/subresources.kubevirt.io", :version => "v1")
+    #method need to call on this kubevirt to restart the vm
+
+  end
+
+  def raw_reset
+    kubevirt = ext_management_system.parent_manager.connect(:service => "kubernetes", :path => "/apis/subresources.kubevirt.io", :version => "v1")
+    #method need to call on this kubevirt to soft reboot the vm
+
+  end
+end


### PR DESCRIPTION
This PR introduces the "Restart VM" feature for VMs managed by the KubeVirt infrastructure provider in ManageIQ.

Testing:
Verified the restart functionality for KubeVirt VMs via the UI.

Before: "Restart Guest" option is disabled for KubeVirt VMs.

After: "Restart Guest" button available and functional for KubeVirt VMs.
![image](https://github.com/user-attachments/assets/0acf7906-a3e0-4667-a2ec-6790898011e5)
![image](https://github.com/user-attachments/assets/ea1f4c2b-75c5-4d10-afd6-75b9a59698f0)

@Fryguy Kindly take a look at this and review the PR. Thank you!