### PR TITLE
[WIP] Remote console access for VM's

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
   include Operations
-
+  include RemoteConsole
   POWER_STATES = {
     'Running'    => 'on',
     'Pending'    => 'powering_up',

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/remote_console.rb
@@ -1,0 +1,5 @@
+module ManageIQ::Providers::Kubevirt::InfraManager::Vm::RemoteConsole
+  def console_supported?(type)
+    %w(VNC).include?(type.upcase)
+  end
+end


### PR DESCRIPTION
Enabling this functionality would allow users to interact directly with their KubeVirt VMs for troubleshooting, configuration and recovery.

@miq-bot add-label wip