### PR TITLE
Remove obsolete SPICE console option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@ manually, or when a new virtual machine is added.
 always performs a full refresh, there are no specific targers (like
 virtual machines, or hosts) implemented yet.
 
-* The `kubeclient` gem that the provider uses to talk to the Kubernetes API
-doesn't support the sub-resource mechanism used by the KubeVirt API for SPICE
-details. In addition Kubernetes itself doesn't yet support sub-resources
-for custom resource definitions. As a result the provider has to extract
-the SPICE proxy URL from the configuration of the `spice-proxy` service.
-
 ## Notes
 
 ### How to get the default token from Kubernetes

--- a/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/connection.rb
@@ -156,13 +156,4 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Connection
   def delete_vm_instance(name, namespace)
     @conn.vminstances.destroy(name, namespace)
   end
-
-  #
-  # Calculates the URL of the SPICE proxy server.
-  #
-  # @return [String] The URL of the spice proxy server.
-  #
-  def spice_proxy_url
-    @conn.spice_proxy_url
-  end
 end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
@@ -23,68 +23,6 @@ class ManageIQ::Providers::Kubevirt::InfraManager::Vm < ManageIQ::Providers::Inf
   end
 
   #
-  # This method is executed in the UI worker. It adds to the queue a task to retrieve the
-  # `remote-viewer` configuration file for a virtual machine.
-  #
-  # @return [Integer] The identifier of the task.
-  #
-  def queue_generate_remote_viewer_file
-    # Create the task options:
-    task_options = {
-      :action => "Generate 'remote-viewer' configuration file for VM '#{name}'"
-    }
-
-    # Create the queue options:
-    queue_options = {
-      :class_name  => self.class.name,
-      :instance_id => id,
-      :method_name => 'generate_remote_viewer_file',
-      :priority    => MiqQueue::HIGH_PRIORITY,
-      :role        => 'ems_operations',
-      :zone        => my_zone,
-      :args        => []
-    }
-
-    # Add the task to the queue and return the identifier:
-    MiqTask.generic_action_with_callback(task_options, queue_options)
-  end
-
-  #
-  # This method is executed in the provider worker. It contacts the KubeVirt API to get the details of the connection to
-  # the console, and generates the `remote-viewer` configuration file.
-  #
-  # @return [String] The content of the cofiguration file.
-  #
-  def generate_remote_viewer_file
-    # Retrieve the details of the the virtual machine and the URL of the SPICE proxy:
-    vm = nil
-    proxy = nil
-    ext_management_system.with_provider_connection do |connection|
-      vm = connection.vm(name)
-      proxy = connection.spice_proxy_url
-    end
-
-    # The virtual machine may have multiple graphics device, get the first one that uses the SPICE protocol:
-    spice = vm.status.graphics.detect { |graphics| graphics.type == 'spice' }
-
-    # Generate the content of the `remote-viewer` configuration file file:
-    file = \
-      "[virt-viewer]\n" \
-      "type=spice\n" \
-      "title=#{name} - Press SHIFT+F12 to Release Cursor\n" \
-      "host=#{spice.host}\n" \
-      "port=#{spice.port}\n" \
-      "proxy=#{proxy}\n" \
-      "delete-this-file=1\n" \
-      "toggle-fullscreen=shift+f11\n" \
-      "release-cursor=shift+f12\n" \
-      "secure-attention=ctrl+alt+del\n"
-
-    # Return the generated file:
-    file
-  end
-
-  #
   # UI Button Validation Methods
   #
 


### PR DESCRIPTION
This was removed by kubevirt in https://github.com/kubevirt/kubevirt/pull/618 and replaced with VNC support

Related: https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/268 adding VNC support

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
