### PR TITLE
Fix cloud_user_password v2-key encrypted

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
@@ -51,7 +51,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Provision::Cloning
     merged_options = options.dup
     merged_options[:cpu_cores] = get_option(:cores_per_socket)
     merged_options[:memory] = get_option(:vm_memory)
-    merged_options[:cloud_user_password] = get_option(:root_password)
+    merged_options[:cloud_user_password] = ManageIQ::Password.try_decrypt(get_option(:root_password))
     merged_options.compact
   end
 end


### PR DESCRIPTION
When provisioning a kubevirt vm the cloud_user_password is being set as the v2-key encrypted string

```
   51:   def user_options(options)
   52:     merged_options = options.dup
   53:     merged_options[:cpu_cores] = get_option(:cores_per_socket)
   54:     merged_options[:memory] = get_option(:vm_memory)
   55:     merged_options[:cloud_user_password] = get_option(:root_password)
=> 56:     merged_options.compact
   57:   end 
   58: end 
(byebug) merged_options
{:name=>"ag-prov-test-2", :cpu_cores=>2, :memory=>"1024", :cloud_user_password=>"v2:{jlrF7Hk6l0rK03aF62GIow==}"}
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
