### PR TITLE
VM Reconfigure

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
   include Operations
+  include Reconfigure
 
   POWER_STATES = {
     'Running'    => 'on',

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations
   extend ActiveSupport::Concern
+
+  include Configuration
   include Power
   include Snapshot
   include Guest

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/configuration.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/configuration.rb
@@ -1,0 +1,33 @@
+module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations::Configuration
+  extend ActiveSupport::Concern
+
+  def raw_set_number_of_cpus(num)
+    raw_reconfigure(
+      [
+        {
+          "op"    => "replace",
+          "path"  => "/spec/template/spec/domain/cpu/sockets",
+          "value" => num
+        }
+      ]
+    )
+  end
+
+  def raw_set_memory(memory_mb)
+    raw_reconfigure(
+      [
+        {
+          "op"    => "replace",
+          "path"  => "/spec/template/spec/domain/memory/guest",
+          "value" => "#{memory_mb}Mi"
+        }
+      ]
+    )
+  end
+
+  def raw_reconfigure(options)
+    with_provider_connection do |connection|
+      connection.patch_namespaced_virtual_machine(name, location, options)
+    end
+  end
+end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure.rb
@@ -6,16 +6,13 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Reconfigure
   end
 
   def max_vcpus
-    host ? host.hardware.cpu_total_cores : raise # TOOD
+    ext_management_system.host_hardwares.pluck(:cpu_total_cores).max
   end
   alias max_total_vcpus max_vcpus
-
-  def max_cpu_cores_per_socket(_total_vcpus = nil)
-    max_vcpus
-  end
+  alias max_cpu_cores_per_socket max_vcpus
 
   def max_memory_mb
-    host.hardware.memory_mb
+    ext_management_system.host_hardwares.pluck(:memory_mb).max
   end
 
   def build_config_spec(options)

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure.rb
@@ -1,0 +1,28 @@
+module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Reconfigure
+  extend ActiveSupport::Concern
+
+  def reconfigurable?
+    active?
+  end
+
+  def max_vcpus
+    host ? host.hardware.cpu_total_cores : raise # TOOD
+  end
+  alias max_total_vcpus max_vcpus
+
+  def max_cpu_cores_per_socket(_total_vcpus = nil)
+    max_vcpus
+  end
+
+  def max_memory_mb
+    host.hardware.memory_mb
+  end
+
+  def build_config_spec(options)
+    patches = []
+    patches << {"op" => "replace", "path" => "/spec/template/spec/domain/cpu/sockets",  "value" => options[:number_of_sockets]} if options[:number_of_sockets]
+    patches << {"op" => "replace", "path" => "/spec/template/spec/domain/cpu/cores",    "value" => options[:cores_per_socket]}  if options[:cores_per_socket]
+    patches << {"op" => "replace", "path" => "/spec/template/spec/domain/memory/guest", "value" => "#{options[:vm_memory]}Mi"}  if options[:vm_memory]
+    patches
+  end
+end

--- a/spec/factories/host_kubevirt.rb
+++ b/spec/factories/host_kubevirt.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :host_kubevirt, :class => "ManageIQ::Providers::Kubevirt::InfraManager::Host", :parent => :host
+end

--- a/spec/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure_spec.rb
@@ -1,0 +1,72 @@
+describe ManageIQ::Providers::Kubevirt::InfraManager::Vm::Reconfigure do
+  let(:ems) { FactoryBot.create(:ems_kubevirt) }
+  let(:vm) { FactoryBot.create(:vm_kubevirt, :ext_management_system => ems) }
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
+
+  describe "#reconfigurable?" do
+    context "with an active vm" do
+      it "is reconfigurable" do
+        expect(vm.reconfigurable?).to be_truthy
+      end
+    end
+
+    context "with an archived vm" do
+      let(:ems) { nil }
+
+      it "is not reconfigurable" do
+        expect(vm.reconfigurable?).to be_falsey
+      end
+    end
+  end
+
+  describe "#max_vcpus" do
+  end
+
+  describe "#max_memory_mb" do
+  end
+
+  describe "#build_config_spec" do
+    let(:memory_mb) { "2048" }
+
+    context "changing memory" do
+      let(:options) do
+        {
+          :src_ids             => [vm.id],
+          :vm_memory           => memory_mb,
+          :request_type        => :vm_reconfigure,
+          :executed_on_servers => [miq_server.id]
+        }
+      end
+
+      it "returns a k8s patch object" do
+        expect(vm.build_config_spec(options)).to match_array(
+          [
+            {"op" => "replace", "path" => "/spec/template/spec/domain/memory/guest", "value" => "2048Mi"}
+          ]
+        )
+      end
+    end
+
+    context "changing cpu topology" do
+      let(:options) do
+        {
+          :src_ids             => [vm.id],
+          :cores_per_socket    => 2,
+          :number_of_sockets   => 2,
+          :number_of_cpus      => 4,
+          :request_type        => :vm_reconfigure,
+          :executed_on_servers => [miq_server.id]
+        }
+      end
+
+      it "returns a k8s patch object" do
+        expect(vm.build_config_spec(options)).to match_array(
+          [
+            {"op" => "replace", "path" => "/spec/template/spec/domain/cpu/sockets", "value" => 2},
+            {"op" => "replace", "path" => "/spec/template/spec/domain/cpu/cores",   "value" => 2}
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure_spec.rb
@@ -20,9 +20,39 @@ describe ManageIQ::Providers::Kubevirt::InfraManager::Vm::Reconfigure do
   end
 
   describe "#max_vcpus" do
+    let!(:host1) { FactoryBot.create(:host_kubevirt, :ext_management_system => ems, :hardware => FactoryBot.create(:hardware, :cpu2x2)) }
+    let!(:host2) { FactoryBot.create(:host_kubevirt, :ext_management_system => ems, :hardware => FactoryBot.create(:hardware, :cpu4x2)) }
+
+    it "returns the highest cpu_total_cores for all hosts in the EMS" do
+      expect(vm.max_vcpus).to eq(8)
+    end
+
+    context "with a host in another EMS" do
+      let(:ems2)   { FactoryBot.create(:ems_kubevirt) }
+      let!(:host2) { FactoryBot.create(:host_kubevirt, :ext_management_system => ems2, :hardware => FactoryBot.create(:hardware, :cpu4x2)) }
+
+      it "doesn't use host with more CPUs from another EMS" do
+        expect(vm.max_vcpus).to eq(4)
+      end
+    end
   end
 
   describe "#max_memory_mb" do
+    let!(:host1) { FactoryBot.create(:host_kubevirt, :ext_management_system => ems, :hardware => FactoryBot.create(:hardware, :memory_mb => 2_048)) }
+    let!(:host2) { FactoryBot.create(:host_kubevirt, :ext_management_system => ems, :hardware => FactoryBot.create(:hardware, :memory_mb => 4_096)) }
+
+    it "returns the highest memory_mb for all hosts in the EMS" do
+      expect(vm.max_memory_mb).to eq(4_096)
+    end
+
+    context "with a host in another EMS" do
+      let(:ems2)   { FactoryBot.create(:ems_kubevirt) }
+      let!(:host2) { FactoryBot.create(:host_kubevirt, :ext_management_system => ems2, :hardware => FactoryBot.create(:hardware, :memory_mb => 4_096)) }
+
+      it "doesn't use host with more memory from another EMS" do
+        expect(vm.max_memory_mb).to eq(2_048)
+      end
+    end
   end
 
   describe "#build_config_spec" do


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/283
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/287

TODO:
- [x] Specs
- [x] Host parser has to set cpus/memory
- [x] Sockets vs total cpus (kubevirt lets you do either, just set num cpus or set topology manually and core assumes you'll set manually, can we even get sockets from kubevirt nodes?)
- [x] What to do if host is nil (vmware would set this based on hardware version but maybe we set it based on the most cpus on any kubevirt host?)
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
