### PR TITLE
Parse VM Sockets and Threads

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -169,12 +169,13 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     vm_object.location = namespace
 
     cpu_sockets          = cpu&.sockets || 1
-    cpu_total_cores      = cpu&.cores || 1
-    cpu_cores_per_socket = cpu_total_cores / cpu_sockets
+    cpu_cores_per_socket = cpu&.cores   || 1
+    cpu_threads_per_core = cpu&.threads || 1
+    cpu_total_cores      = cpu_sockets * cpu_cores_per_socket * cpu_threads_per_core
 
     # Create the inventory object for the hardware:
     hw_object = hw_collection.find_or_build(vm_object)
-    hw_object.memory_mb            = parse_quantity(memory) / 1.megabytes.to_f if memory
+    hw_object.memory_mb            = parse_quantity(memory) / 1.megabyte.to_f if memory
     hw_object.cpu_sockets          = cpu_sockets
     hw_object.cpu_cores_per_socket = cpu_cores_per_socket
     hw_object.cpu_total_cores      = cpu_total_cores

--- a/app/models/manageiq/providers/kubevirt/inventory/parser.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/parser.rb
@@ -145,7 +145,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     end
 
     # Process the domain:
-    vm_object = process_domain(object.metadata.namespace, object.spec.domain.memory&.guest, object.spec.domain.cpu&.cores, uid, name)
+    vm_object = process_domain(object.metadata.namespace, object.spec.domain.memory&.guest, object.spec.domain.cpu, uid, name)
 
     process_status(vm_object, object.status.interfaces&.first&.ipAddress, object.status.nodeName)
 
@@ -154,7 +154,7 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     vm_object.raw_power_state = object.status.phase
   end
 
-  def process_domain(namespace, memory, cores, uid, name)
+  def process_domain(namespace, memory, cpu, uid, name)
     # Find the storage:
     storage_object = storage_collection.lazy_find(STORAGE_ID)
     # Create the inventory object for the virtual machine:
@@ -168,11 +168,16 @@ class ManageIQ::Providers::Kubevirt::Inventory::Parser < ManageIQ::Providers::In
     vm_object.uid_ems = uid
     vm_object.location = namespace
 
+    cpu_sockets          = cpu&.sockets || 1
+    cpu_total_cores      = cpu&.cores || 1
+    cpu_cores_per_socket = cpu_total_cores / cpu_sockets
+
     # Create the inventory object for the hardware:
     hw_object = hw_collection.find_or_build(vm_object)
-    hw_object.memory_mb = parse_quantity(memory) / 1.megabytes.to_f if memory
-    hw_object.cpu_cores_per_socket = cores
-    hw_object.cpu_total_cores = cores
+    hw_object.memory_mb            = parse_quantity(memory) / 1.megabytes.to_f if memory
+    hw_object.cpu_sockets          = cpu_sockets
+    hw_object.cpu_cores_per_socket = cpu_cores_per_socket
+    hw_object.cpu_total_cores      = cpu_total_cores
 
     # Return the created inventory object:
     vm_object

--- a/spec/models/manageiq/providers/kubevirt/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/infra_manager/refresher_spec.rb
@@ -53,6 +53,13 @@ describe ManageIQ::Providers::Kubevirt::InfraManager::Refresher do
         :power_state      => "on",
         :connection_state => "connected"
       )
+
+      expect(vm.hardware).to have_attributes(
+        :cpu_cores_per_socket => 1,
+        :cpu_sockets          => 1,
+        :cpu_total_cores      => 1,
+        :memory_mb            => 2_048
+      )
     end
 
     def assert_specific_host


### PR DESCRIPTION
Previously we were only looking at "spec.domain.cpu.cores" but if you let kubevirt pick the cpu topology it will set e.g. "4 cpus" as 4 sockets, 1 core, 1 thread:

![image](https://github.com/user-attachments/assets/900cf326-d193-42b9-be0f-4503bb98a00b)

```
    spec:
      architecture: amd64
      domain:
        cpu:
          cores: 1
          sockets: 4
          threads: 1
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
