### PR TITLE
Allow VM reconfigure with instance_types / flavors

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/configuration.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/operations/configuration.rb
@@ -25,6 +25,10 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Operations::Configuratio
     )
   end
 
+  def raw_set_flavor(flavor_id)
+    raw_reconfigure(build_config_spec(:flavor_id => flavor_id))
+  end
+
   def raw_reconfigure(options)
     with_provider_connection do |connection|
       connection.patch_namespaced_virtual_machine(name, location, options)

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure.rb
@@ -15,7 +15,21 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Reconfigure
     ext_management_system.host_hardwares.pluck(:memory_mb).max
   end
 
+  def validate_config_spec(options)
+    if flavor
+      if %i[number_of_sockets cores_per_socket vm_memory].any? { |key| options.key?(key) }
+        raise MiqException::MiqVmError, _("Setting CPUs / Memory not supported for instance_type VMs")
+      end
+    else
+      if options.key?(:flavor_id)
+        raise MiqException::MiqVmError, _("Setting instance_type not supported for template VMs")
+      end
+    end
+  end
+
   def build_config_spec(options)
+    validate_config_spec(options)
+
     patches = []
     if options[:flavor_id]
       flavor = ext_management_system.flavors.find(options[:flavor_id])

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/reconfigure.rb
@@ -17,9 +17,14 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::Reconfigure
 
   def build_config_spec(options)
     patches = []
-    patches << {"op" => "replace", "path" => "/spec/template/spec/domain/cpu/sockets",  "value" => options[:number_of_sockets]} if options[:number_of_sockets]
-    patches << {"op" => "replace", "path" => "/spec/template/spec/domain/cpu/cores",    "value" => options[:cores_per_socket]}  if options[:cores_per_socket]
-    patches << {"op" => "replace", "path" => "/spec/template/spec/domain/memory/guest", "value" => "#{options[:vm_memory]}Mi"}  if options[:vm_memory]
+    if options[:flavor_id]
+      flavor = ext_management_system.flavors.find(options[:flavor_id])
+      patches << {"op" => "replace", "path" => "/spec/instancetype", "value" => {"kind" => "VirtualMachineClusterInstancetype", "name" => flavor.name}}
+    else
+      patches << {"op" => "replace", "path" => "/spec/template/spec/domain/cpu/sockets",  "value" => options[:number_of_sockets]} if options[:number_of_sockets]
+      patches << {"op" => "replace", "path" => "/spec/template/spec/domain/cpu/cores",    "value" => options[:cores_per_socket]}  if options[:cores_per_socket]
+      patches << {"op" => "replace", "path" => "/spec/template/spec/domain/memory/guest", "value" => "#{options[:vm_memory]}Mi"}  if options[:vm_memory]
+    end
     patches
   end
 end


### PR DESCRIPTION
If a VM is created from an instance_type it doesn't have a `spec/template/spec/domain/{cpu,memory}` section but rather a `spec/instancetype` section.

We still need to change the reconfigure dialog to optionally display instance_types instead of just cpu/memory but this gets the API call to kubernetes working.

https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/296
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
