### PR TITLE
Fix vm spec running run strategy

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/provision/cloning.rb
@@ -36,7 +36,7 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Provision::Cloning
       raise N_("No Virtual Machine defined in template") if vm_spec.nil?
 
       param_substitution!(vm_spec, params)
-      vm_spec.deep_merge!(:spec => {:running => false}, :metadata => {:namespace => namespace})
+      vm_spec.deep_merge!(:spec => {:runStrategy => "Halted"}, :metadata => {:namespace => namespace})
 
       create_persistent_volume_claims(pvc_specs, params, namespace) if pvc_specs.any?
 


### PR DESCRIPTION
Fix spec.running and runStrategy both set for a VM The `v1.VirtualMachineSpec` has deprecated `running` in favor of
`runStrategy` and will fail if both are present.

This fixes the error `Running and RunStrategy are mutually exclusive. Note that Running is deprecated, please use RunStrategy instead`

https://kubevirt.io/api-reference/main/definitions.html#_v1_virtualmachinespec

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/307

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/306
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
