### PR TITLE
Cleanup unreachable targeted refresh code and split full/partial inventory collector

### DIFF
--- a/app/models/manageiq/providers/kubevirt/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/collector.rb
@@ -15,40 +15,10 @@ class ManageIQ::Providers::Kubevirt::Inventory::Collector < ManageIQ::Providers:
   def initialize(manager, refresh_target)
     super
 
-    if refresh_target.kind_of?(ManageIQ::Providers::Kubevirt::InfraManager::Vm)
-      initialize_for_targeted_refresh
-    else
-      initialize_for_full_refresh
-    end
-  end
-
-  protected
-
-  def initialize_for_targeted_refresh
-    name      = @target.name
-    namespace = @target.location
-
-    @nodes          = {}
-    @instance_types = {}
-
-    if @target.template?
-      @templates = [@manager.kubeclient("template.openshift.io/v1").template(name, namespace)]
-    else
-      @vms = [@manager.kubeclient("kubevirt.io/v1")..get_virtual_machine(name, namespace)]
-      begin
-        @vm_instances = [@manager.kubeclient("kubevirt.io/v1")..get_virtual_machine_instance(name, namespace)]
-      rescue
-        # target refresh of a vm might fail if it has no vm instance
-        _log.debug("The is no running vm resource for '#{name}'")
-      end
-    end
-  end
-
-  def initialize_for_full_refresh
-    @nodes = @manager.kubeclient.get_nodes
+    @nodes          = @manager.kubeclient.get_nodes
     @instance_types = @manager.kubeclient("instancetype.kubevirt.io/v1beta1").get_virtual_machine_cluster_instancetypes
-    @vms = @manager.kubeclient("kubevirt.io/v1").get_virtual_machines
-    @vm_instances = @manager.kubeclient("kubevirt.io/v1").get_virtual_machine_instances
-    @templates = @manager.kubeclient("template.openshift.io/v1").get_templates
+    @vms            = @manager.kubeclient("kubevirt.io/v1").get_virtual_machines
+    @vm_instances   = @manager.kubeclient("kubevirt.io/v1").get_virtual_machine_instances
+    @templates      = @manager.kubeclient("template.openshift.io/v1").get_templates
   end
 end


### PR DESCRIPTION
Kubevirt uses streaming refresh and does not support classic "targeted" refresh.  Even if you did request a targeted refresh of a single VM the refresh_targets are converted into a `InventoryRefresh::TargetCollection` and not a `Vm` instance like this was expecting.