### PR TITLE
Fix full refresh collection during targeted

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -61,8 +61,8 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
     provider_class::InfraManager
   end
 
-  def collector_class
-    provider_class::Inventory::Collector
+  def partial_refresh_collector_class
+    provider_class::Inventory::Collector::PartialRefresh
   end
 
   def partial_refresh_parser_class
@@ -161,7 +161,7 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
     relevant.reverse!
 
     # Create and populate the collector:
-    collector = collector_class.new(manager, nil)
+    collector = partial_refresh_collector_class.new(manager, nil)
     collector.nodes = notices_of_kind(relevant, 'Node')
     collector.vms = notices_of_kind(relevant, 'VirtualMachine')
     collector.vm_instances = notices_of_kind(relevant, 'VirtualMachineInstance')

--- a/app/models/manageiq/providers/kubevirt/inventory.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory.rb
@@ -4,7 +4,7 @@ class ManageIQ::Providers::Kubevirt::Inventory < ManageIQ::Providers::Inventory
   end
 
   def self.collector_class_for(_ems, _target)
-    ManageIQ::Providers::Kubevirt::Inventory::Collector
+    ManageIQ::Providers::Kubevirt::Inventory::Collector::FullRefresh
   end
 
   def self.parser_class_for(_ems, _target)

--- a/app/models/manageiq/providers/kubevirt/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/collector.rb
@@ -1,24 +1,7 @@
-#
-# This class contains the data needed to perform a refresh. The data are the collections of nodes, virtual machines and
-# templates retrieved using the KubeVirt API.
-#
-# Note that unlike other typical collectors it doesn't really retrieve that data itself: the refresh worker will create
-# with the data that it already obtained from the KubeVirt API.
-#
 class ManageIQ::Providers::Kubevirt::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   attr_accessor :nodes
   attr_accessor :instance_types
   attr_accessor :vms
   attr_accessor :vm_instances
   attr_accessor :templates
-
-  def initialize(manager, refresh_target)
-    super
-
-    @nodes          = @manager.kubeclient.get_nodes
-    @instance_types = @manager.kubeclient("instancetype.kubevirt.io/v1beta1").get_virtual_machine_cluster_instancetypes
-    @vms            = @manager.kubeclient("kubevirt.io/v1").get_virtual_machines
-    @vm_instances   = @manager.kubeclient("kubevirt.io/v1").get_virtual_machine_instances
-    @templates      = @manager.kubeclient("template.openshift.io/v1").get_templates
-  end
 end

--- a/app/models/manageiq/providers/kubevirt/inventory/collector/full_refresh.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/collector/full_refresh.rb
@@ -1,0 +1,18 @@
+#
+# This class contains the data needed to perform a refresh. The data are the collections of nodes, virtual machines and
+# templates retrieved using the KubeVirt API.
+#
+# Note that unlike other typical collectors it doesn't really retrieve that data itself: the refresh worker will create
+# with the data that it already obtained from the KubeVirt API.
+#
+class ManageIQ::Providers::Kubevirt::Inventory::Collector::FullRefresh < ManageIQ::Providers::Kubevirt::Inventory::Collector
+  def initialize(manager, refresh_target)
+    super
+
+    @nodes          = @manager.kubeclient.get_nodes
+    @instance_types = @manager.kubeclient("instancetype.kubevirt.io/v1beta1").get_virtual_machine_cluster_instancetypes
+    @vms            = @manager.kubeclient("kubevirt.io/v1").get_virtual_machines
+    @vm_instances   = @manager.kubeclient("kubevirt.io/v1").get_virtual_machine_instances
+    @templates      = @manager.kubeclient("template.openshift.io/v1").get_templates
+  end
+end

--- a/app/models/manageiq/providers/kubevirt/inventory/collector/partial_refresh.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/collector/partial_refresh.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Kubevirt::Inventory::Collector::PartialRefresh < ManageIQ::Providers::Kubevirt::Inventory::Collector
+end


### PR DESCRIPTION
The `initialize_for_full_refresh` method was being called for targeted refreshes because we are passing `nil` in for the `refresh_target` [[ref]](https://github.com/ManageIQ/manageiq-providers-kubevirt/blob/master/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb#L164) which went down the full_refresh conditional branch in the collector initializer [[ref]](https://github.com/ManageIQ/manageiq-providers-kubevirt/blob/master/app/models/manageiq/providers/kubevirt/inventory/collector.rb#L18-L22)

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/310

Follow-up:
* https://github.com/ManageIQ/manageiq-providers-openshift/pull/293
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
