### PR TITLE
Move watch notice processing into Collector

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb
@@ -154,23 +154,9 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
       end
     end
 
-    # The notices returned by the Kubernetes API contain always the complete representation of the object, so it isn't
-    # necessary to process all of them, only the last one for each object.
-    relevant = notices.reverse!
-    relevant.uniq!(&:uid)
-    relevant.reverse!
-
-    # Create and populate the collector:
-    collector = partial_refresh_collector_class.new(manager, nil)
-    collector.nodes = notices_of_kind(relevant, 'Node')
-    collector.vms = notices_of_kind(relevant, 'VirtualMachine')
-    collector.vm_instances = notices_of_kind(relevant, 'VirtualMachineInstance')
-    collector.templates = notices_of_kind(relevant, 'VirtualMachineTemplate')
-    collector.instance_types = notices_of_kind(relevant, 'VirtualMachineClusterInstanceType')
-
-    # Create the parser and persister, wire them, and execute the persist:
+    collector = partial_refresh_collector_class.new(manager, notices)
     persister = persister_class.new(manager, nil)
-    parser = partial_refresh_parser_class.new
+    parser    = partial_refresh_parser_class.new
     parser.collector = collector
     parser.persister = persister
     parser.parse
@@ -186,17 +172,6 @@ class ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker::Runner < Manag
     _log.error('Partial refresh failed.')
     _log.log_backtrace(error)
     manager.update(:last_refresh_error => error.to_s, :last_refresh_date => Time.now.utc)
-  end
-
-  #
-  # Returns the notices that contain objects of the given kind.
-  #
-  # @param notices [Array] An array of notices.
-  # @param kind [String] The kind of object, for example `Node`.
-  # @return [Array] An array containing the notices that have the given kind.
-  #
-  def notices_of_kind(notices, kind)
-    notices.select { |notice| notice.object.kind == kind }
   end
 
   #

--- a/app/models/manageiq/providers/kubevirt/inventory/collector.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/collector.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Kubevirt::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  attr_accessor :nodes
-  attr_accessor :instance_types
-  attr_accessor :vms
-  attr_accessor :vm_instances
-  attr_accessor :templates
+  attr_reader :nodes
+  attr_reader :instance_types
+  attr_reader :vms
+  attr_reader :vm_instances
+  attr_reader :templates
 end

--- a/app/models/manageiq/providers/kubevirt/inventory/collector/partial_refresh.rb
+++ b/app/models/manageiq/providers/kubevirt/inventory/collector/partial_refresh.rb
@@ -1,2 +1,30 @@
 class ManageIQ::Providers::Kubevirt::Inventory::Collector::PartialRefresh < ManageIQ::Providers::Kubevirt::Inventory::Collector
+  def initialize(manager, notices)
+    super(manager, nil)
+
+    # The notices returned by the Kubernetes API contain always the complete representation of the object, so it isn't
+    # necessary to process all of them, only the last one for each object.
+    notices.reverse!
+    notices.uniq!(&:uid)
+    notices.reverse!
+
+    @nodes          = notices_of_kind(notices, 'Node')
+    @vms            = notices_of_kind(notices, 'VirtualMachine')
+    @vm_instances   = notices_of_kind(notices, 'VirtualMachineInstance')
+    @templates      = notices_of_kind(notices, 'VirtualMachineTemplate')
+    @instance_types = notices_of_kind(notices, 'VirtualMachineClusterInstanceType')
+  end
+
+  private
+
+  #
+  # Returns the notices that contain objects of the given kind.
+  #
+  # @param notices [Array] An array of notices.
+  # @param kind [String] The kind of object, for example `Node`.
+  # @return [Array] An array containing the notices that have the given kind.
+  #
+  def notices_of_kind(notices, kind)
+    notices.select { |notice| notice.object.kind == kind }
+  end
 end

--- a/spec/models/manageiq/providers/kubevirt/inventory/collector/partial_refresh_spec.rb
+++ b/spec/models/manageiq/providers/kubevirt/inventory/collector/partial_refresh_spec.rb
@@ -1,0 +1,36 @@
+autoload(:Kubeclient, 'kubeclient')
+
+describe ManageIQ::Providers::Kubevirt::Inventory::Collector::PartialRefresh do
+  let(:ems)       { FactoryBot.create(:ems_kubevirt) }
+  let(:collector) { described_class.new(ems, notices) }
+  let(:notices)   { [] }
+
+  context "with no notices" do
+    it "collections are empty" do
+      expect(collector.nodes).to          be_empty
+      expect(collector.vms).to            be_empty
+      expect(collector.vm_instances).to   be_empty
+      expect(collector.templates).to      be_empty
+      expect(collector.instance_types).to be_empty
+    end
+  end
+
+  context "with a vm notice" do
+    let(:vm)        { Kubeclient::Resource.new(:apiVersion => "kubevirt.io/v1", :kind => "VirtualMachine", :metadata => {:name => "my-vm", :namespace => "default", :uid => SecureRandom.uuid})}
+    let(:vm_notice) { Kubeclient::Resource.new(:type => "MODIFIED", :object => vm) }
+    let(:notices)   { [vm_notice] }
+
+    it "#vms" do
+      expect(collector.vms).to include(vm_notice)
+    end
+
+    context "with multiple notices for the same object" do
+      let(:vm_notice2) { Kubeclient::Resource.new(:type => "MODIFIED", :object => vm) }
+      let(:notices)    { [vm_notice, vm_notice2] }
+
+      it "only exposes a single notice" do
+        expect(collector.vms.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move the logic for handling watch notices and populating collector collections into the collector and out of the `RefreshWorker::Runner`

This is closer to the way the Kubernetes ContainerManager handles watch notices, we still can't move 100% to that because the Parser needs Notice objects for now but it gets us closer and cleans up the `RefreshWorker::Runner`.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
