### PR TITLE
Fix VM Memory Metrics always 100%

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/metrics_capture/prometheus_capture_context.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/metrics_capture/prometheus_capture_context.rb
@@ -49,17 +49,17 @@ class ManageIQ::Providers::Kubevirt::InfraManager::MetricsCapture::PrometheusCap
     cpu_resid = "sum(rate(kubevirt_vmi_cpu_user_usage_seconds_total{#{labels}}[#{AVG_OVER}]))"
     fetch_counters_data(cpu_resid, 'cpu_usage_rate_average', @vm_cores / 100.0)
 
-    # prometheus field is in bytes, @vm_memory is in mb
+    # prometheus field is in bytes, @vm_memory is in MiB
     # miq field is in pct of vm memory
-    mem_resid = "sum(kubevirt_vmi_memory_domain_bytes{#{labels}})"
-    fetch_counters_data(mem_resid, 'mem_usage_absolute_average', @vm_memory * 1e6 / 100.0)
+    mem_resid = "sum(kubevirt_vmi_memory_used_bytes{#{labels}})"
+    fetch_counters_data(mem_resid, 'mem_usage_absolute_average', @vm_memory * 1.megabyte.to_f / 100.0)
 
     # prometheus field is in bytes
-    # miq field is on kb ( / 1000 )
+    # miq field is on KiB ( / 1024 )
     if @metrics.include?('net_usage_rate_average')
       net_resid = "sum(rate(kubevirt_vmi_network_receive_bytes_total{#{labels}\"}[#{AVG_OVER}])) + " \
                   "sum(rate(kubevirt_vmi_network_transmit_bytes_total{#{labels}\"}[#{AVG_OVER}]))"
-      fetch_counters_data(net_resid, 'net_usage_rate_average', 1000.0)
+      fetch_counters_data(net_resid, 'net_usage_rate_average', 1024.0)
     end
 
     @ts_values


### PR DESCRIPTION
From discussion: https://github.com/orgs/ManageIQ/discussions/23684

Replace `kubevirt_vmi_memory_domain_bytes` with `kubevirt_vmi_memory_used_bytes`

`memory_domain_bytes` is the "allocated" memory from the VM YAML spec.
`memory_used_bytes` is the "used" memory

Metrics chart for this vm:
<img width="792" height="521" alt="image" src="https://github.com/user-attachments/assets/3b38a765-2611-440e-88a4-3dc9e317cb20" />

You can see when it was showing 100%, when it was calculating against 2048 base-10, and when it is correct

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/317
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
