### PR TITLE
Add HTML5 VNC remote console support for KubeVirt VMs

### DIFF
--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb
@@ -1,7 +1,8 @@
 class ManageIQ::Providers::Kubevirt::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
   include Operations
   include Reconfigure
-
+  include RemoteConsole
+  
   POWER_STATES = {
     'Running'    => 'on',
     'Pending'    => 'powering_up',

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/remote_console.rb
@@ -1,0 +1,52 @@
+module ManageIQ::Providers::Kubevirt::InfraManager::Vm::RemoteConsole
+  def console_supported?(type)
+    %w[VNC HTML5].include?(type.upcase)
+  end
+
+  def validate_remote_console_acquire_ticket(protocol, _options = {})
+    raise(MiqException::RemoteConsoleNotSupportedError, "#{protocol} remote console requires the vm to be registered with a management system.") if ext_management_system.nil?
+    raise(MiqException::RemoteConsoleNotSupportedError, "#{protocol} remote console requires the vm to be running.") unless state == "on"
+  end
+
+  def remote_console_acquire_ticket(userid, originating_server, protocol)
+    send("remote_console_#{protocol.to_s.downcase}_acquire_ticket", userid, originating_server)
+  end
+
+  def remote_console_acquire_ticket_queue(protocol, userid)
+    task_opts = {:action => "acquiring VM #{name} #{protocol.to_s.upcase} remote console ticket for user #{userid}", :userid => userid}
+    queue_opts = {
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :method_name => 'remote_console_acquire_ticket',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => [userid, MiqServer.my_server.id, protocol]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def remote_console_vnc_acquire_ticket(userid, originating_server = nil)
+    validate_remote_console_acquire_ticket("vnc")
+
+    SystemConsole.force_vm_invalid_token(id)
+
+    api_uri = ext_management_system.parent_manager.api_endpoint
+
+    console_args = {
+      :user       => User.find_by(:userid => userid),
+      :vm_id      => id,
+      :ssl        => true,
+      :protocol   => 'kubevirt_vnc',
+      :secret     => SecureRandom.hex,
+      :url_secret => SecureRandom.hex
+    }
+
+    SystemConsole.launch_proxy_if_not_local(console_args, originating_server, api_uri.host, api_uri.port)
+  end
+
+  def remote_console_html5_acquire_ticket(userid, originating_server = nil)
+    remote_console_vnc_acquire_ticket(userid, originating_server)
+  end
+end

--- a/app/models/manageiq/providers/kubevirt/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/kubevirt/infra_manager/vm/remote_console.rb
@@ -4,8 +4,15 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::RemoteConsole
   end
 
   def validate_remote_console_acquire_ticket(protocol, _options = {})
-    raise(MiqException::RemoteConsoleNotSupportedError, "#{protocol} remote console requires the vm to be registered with a management system.") if ext_management_system.nil?
-    raise(MiqException::RemoteConsoleNotSupportedError, "#{protocol} remote console requires the vm to be running.") unless state == "on"
+    if ext_management_system.nil?
+      raise(MiqException::RemoteConsoleNotSupportedError,
+            "#{protocol} remote console requires the vm to be registered with a management system.")
+    end
+
+    unless state == "on"
+      raise(MiqException::RemoteConsoleNotSupportedError,
+            "#{protocol} remote console requires the vm to be running.")
+    end
   end
 
   def remote_console_acquire_ticket(userid, originating_server, protocol)
@@ -13,17 +20,22 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::RemoteConsole
   end
 
   def remote_console_acquire_ticket_queue(protocol, userid)
-    task_opts = {:action => "acquiring VM #{name} #{protocol.to_s.upcase} remote console ticket for user #{userid}", :userid => userid}
+    task_opts = {
+      :action => "acquiring VM #{name} #{protocol.to_s.upcase} remote console ticket for user #{userid}",
+      :userid => userid
+    }
+
     queue_opts = {
       :class_name  => self.class.name,
       :instance_id => id,
-      :method_name => 'remote_console_acquire_ticket',
+      :method_name => "remote_console_acquire_ticket",
       :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :priority    => MiqQueue::HIGH_PRIORITY,
-      :role        => 'ems_operations',
+      :role        => "ems_operations",
       :zone        => my_zone,
       :args        => [userid, MiqServer.my_server.id, protocol]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
@@ -38,15 +50,40 @@ module ManageIQ::Providers::Kubevirt::InfraManager::Vm::RemoteConsole
       :user       => User.find_by(:userid => userid),
       :vm_id      => id,
       :ssl        => true,
-      :protocol   => 'kubevirt_vnc',
+      :protocol   => "kubevirt_vnc",
       :secret     => SecureRandom.hex,
-      :url_secret => SecureRandom.hex
+      :url_secret => SecureRandom.hex,
+      :url        => build_kubevirt_vnc_url(api_uri)
     }
 
-    SystemConsole.launch_proxy_if_not_local(console_args, originating_server, api_uri.host, api_uri.port)
+    SystemConsole.launch_proxy_if_not_local(
+      console_args,
+      originating_server,
+      api_uri.host,
+      api_uri.port
+    )
   end
 
   def remote_console_html5_acquire_ticket(userid, originating_server = nil)
     remote_console_vnc_acquire_ticket(userid, originating_server)
+  end
+
+  private
+
+  def build_kubevirt_vnc_url(api_uri)
+    URI::Generic.build(
+      :scheme => "wss",
+      :host   => api_uri.host,
+      :port   => api_uri.port,
+      :path   => kubevirt_vnc_path
+    ).to_s
+  end
+
+  def kubevirt_vnc_path
+    "/apis/subresources.kubevirt.io/v1/namespaces/#{kubevirt_namespace}/virtualmachineinstances/#{name}/vnc"
+  end
+
+  def kubevirt_namespace
+    "default"
   end
 end


### PR DESCRIPTION
# Purpose

Add support for acquiring HTML5 VNC remote console tickets for KubeVirt virtual machines.

This implementation introduces the KubeVirt-specific remote console acquisition flow and creates the required SystemConsole record for proxying console connections through ManageIQ.

## Changes

- Add KubeVirt remote console support.
- Implement VNC ticket acquisition.
- Add HTML5 console support using the existing VNC workflow.
- Create SystemConsole entries for KubeVirt consoles.
- Queue remote console acquisition through EMS operations.

## Testing

- Verified remote console ticket generation.
- Verified SystemConsole records are created.
- Verified console launch request reaches ManageIQ.

## Depends On

- https://github.com/ManageIQ/manageiq-ui-classic/pull/10204
- https://github.com/ManageIQ/manageiq/pull/23944

